### PR TITLE
Redo test run progress output.

### DIFF
--- a/library.dylan
+++ b/library.dylan
@@ -22,17 +22,18 @@ end library testworks;
 // Public API
 define module testworks
 
-  // Top level
+  // Top level and test runners
   create
     run-test-application,
     run-tests,
     <test-runner>,
     runner-tags,
-    runner-announce-function,
-    runner-progress-function,
+    runner-ignore,
+    runner-output-stream,
+    runner-progress,
     debug-runner?;
 
-  // Checks
+  // Checks (deprecated, use assertions)
   create
     check,
     check-condition,
@@ -142,15 +143,13 @@ define module %testworks
     <check-result>,
     <test-unit-result>;
 
-  // Progress functions
+  // Progress
   export
-    *default-progress-function*,
-    null-progress-function,
-    full-progress-function;
+    show-progress,
+    $default, $verbose;
 
   // Report functions
   export
-    *default-report-function*,
     null-report-function,
     summary-report-function,
     failures-report-function,

--- a/reports.dylan
+++ b/reports.dylan
@@ -152,6 +152,7 @@ define method summary-report-function
   print-class-summary(result, "check", <check-result>);
 end method summary-report-function;
 
+// TODO(cgay): delete this when log-report-function is deleted.
 define method failures-report-function
     (result :: <result>, stream :: <stream>) => ()
   if (result.result-status ~= $passed)
@@ -171,8 +172,6 @@ define method full-report-function
   print-result-info(result, stream, test: always(#t));
   summary-report-function(result, stream);
 end method full-report-function;
-
-define variable *default-report-function* = failures-report-function;
 
 
 /// Log report

--- a/tests/testworks-test-suite.dylan
+++ b/tests/testworks-test-suite.dylan
@@ -281,10 +281,8 @@ end suite testworks-assertion-macros-suite;
 
 define test test-run-tests/test ()
   let test-to-check = find-test-object(testworks-check-test);
-  let runner = make(<test-runner>,
-                    progress-function: always(#f),
-                    announce-function: always(#f));
-  let test-results = run-tests(runner, test-to-check, report-function: #f);
+  let runner = make(<test-runner>, progress: #f);
+  let test-results = run-tests(runner, test-to-check);
   assert-true(instance?(test-results, <test-result>),
               "run-tests returns <test-result> when running a <test>");
   assert-equal($passed, test-results.result-status,
@@ -295,16 +293,14 @@ end test test-run-tests/test;
 
 define test test-run-tests/suite ()
   let suite-to-check = testworks-assertion-macros-suite;
-  let runner = make(<test-runner>,
-                    progress-function: always(#f),
-                    announce-function: always(#f));
-  let suite-results = run-tests(runner, suite-to-check, report-function: #f);
+  let runner = make(<test-runner>, progress: #f);
+  let suite-results = run-tests(runner, suite-to-check);
   assert-true(instance?(suite-results, <suite-result>),
               "run-tests returns <suite-result> when running a <suite>");
   assert-equal($passed, suite-results.result-status,
                "run-tests returns $passed when passing");
   assert-true(instance?(suite-results.result-subresults, <vector>),
-              "run-tests sub-results are in a vector")
+              "run-tests sub-results are in a vector");
 end test test-run-tests/suite;
 
 // This simply exercises the with-test-unit macro.  It'll catch


### PR DESCRIPTION
Command line option is now --progress=none|default|verbose.  Default is to show suites and tests, but for assertions only display ., S, or X (passed, skipped, or not implemented) unless there's a failure.

Fixes #18 
