### PR TITLE
Add back basic benchmark support.

### DIFF
--- a/documentation/users-guide/source/reference.rst
+++ b/documentation/users-guide/source/reference.rst
@@ -362,7 +362,7 @@ Test Execution
    Run a test suite or test as part of a stand-alone test executable.
 
    :signature: run-test-application *suite-or-test* => ()
-   :parameter suite-or-test: An instance of :class:`<suite>` or :class:`<test>`.
+   :parameter suite-or-test: An instance of :class:`<suite>` or :class:`<runnable>`.
 
    This is the main entry point to run a set of tests in Testworks.
    It parses the command-line and based on the specified options

--- a/library.dylan
+++ b/library.dylan
@@ -54,13 +54,11 @@ define module testworks
     assert-true,
     assert-false;
 
-  // Suites
+  // Components
   create
-    suite-definer;
-
-  // Tests
-  create
+    suite-definer,
     test-definer,
+    benchmark-definer,
     with-test-unit;
 
   // Output
@@ -79,7 +77,7 @@ define module %testworks
   use print, import: { print-object };
   use standard-io;
   use streams;
-  use strings, import: { char-compare-ic, starts-with? };
+  use strings, import: { char-compare-ic, starts-with?, string-equal? };
   use testworks;
   use threads,
     import: { dynamic-bind };
@@ -100,12 +98,15 @@ define module %testworks
     component-name,
     status-name;
 
-  // Tests
+  // Tests and benchmarks
   export
+    <runnable>,
+    <benchmark>,
     <test>,
     <test-unit>,
+    find-runnable,
     test-function,
-    find-test,
+    test-requires-assertions?,
     test-tags;
 
   // Suites
@@ -134,6 +135,7 @@ define module %testworks
     result-subresults,
 
     <test-result>,
+    <benchmark-result>,
     <suite-result>,
     <unit-result>,
     result-reason,

--- a/reports.dylan
+++ b/reports.dylan
@@ -148,7 +148,8 @@ define method summary-report-function
                                      end)
         end;
   print-class-summary(result, "suite", <suite-result>);
-  print-class-summary(result, "test",  <test-result>);
+  print-class-summary(result, "test", <test-result>);
+  print-class-summary(result, "benchmark", <benchmark-result>);
   print-class-summary(result, "check", <check-result>);
 end method summary-report-function;
 

--- a/results.dylan
+++ b/results.dylan
@@ -60,6 +60,9 @@ end class <component-result>;
 define class <test-result> (<component-result>)
 end;
 
+define class <benchmark-result> (<component-result>)
+end;
+
 define class <suite-result> (<component-result>)
 end;
 

--- a/run.dylan
+++ b/run.dylan
@@ -163,7 +163,7 @@ define method execute-component
 end method execute-component;
 
 define method execute-component
-    (test :: <test>, runner :: <test-runner>)
+    (test :: <runnable>, runner :: <test-runner>)
  => (subresults :: <sequence>, status :: <result-status>, reason :: false-or(<string>),
      seconds :: <integer>, microseconds :: <integer>, bytes :: <integer>)
   let subresults = make(<stretchy-vector>);
@@ -188,7 +188,7 @@ define method execute-component
         case
           instance?(cond, <serious-condition>) =>
             values($crashed, format-to-string("%s", cond));
-          empty?(subresults) & ~test.test-allow-empty? =>
+          empty?(subresults) & test.test-requires-assertions? =>
             $not-implemented;
           every?(method (result :: <unit-result>) => (passed? :: <boolean>)
                    result.result-status == $passed
@@ -203,7 +203,7 @@ define method execute-component
 end method execute-component;
 
 define method list-component
-    (test :: <test>, runner :: <test-runner>)
+    (test :: <runnable>, runner :: <test-runner>)
  => (list :: <sequence>)
   if (execute-component?(test, runner))
     vector(test)
@@ -259,9 +259,9 @@ define method show-progress
   end;
 end method show-progress;
 
-// Tests are displayed before and after being run.
+// Tests and benchmarks are displayed before and after being run.
 define method show-progress
-    (runner :: <test-runner>, test :: <test>, result :: false-or(<result>))
+    (runner :: <test-runner>, test :: <runnable>, result :: false-or(<result>))
  => ()
   let verbose? = runner.runner-progress = $verbose;
   if (result)
@@ -272,8 +272,10 @@ define method show-progress
                 result.result-time);
     reason & test-output("    %s\n", reason);
   else
-    test-output("Running test %s:%s",
-                test.component-name, verbose? & "\n" | "");
+    test-output("Running %s %s:%s",
+                test.component-type-name,
+                test.component-name,
+                verbose? & "\n" | "");
   end;
 end method show-progress;
 

--- a/specs/protocol-specs.dylan
+++ b/specs/protocol-specs.dylan
@@ -261,19 +261,19 @@ end macro protocol-spec-bindings-definer;
 
 define macro protocol-spec-suite-definer
   { define protocol-spec-suite ?protocol-name:name => ?spec:name end }
-    => { define test ?protocol-name ## "-protocol-classes-test" (allow-empty: #t)
+    => { define test ?protocol-name ## "-protocol-classes-test" (requires-assertions?: #f)
            check-protocol-classes(?spec)
          end;
-         define test ?protocol-name ## "-protocol-functions-test" (allow-empty: #t)
+         define test ?protocol-name ## "-protocol-functions-test" (requires-assertions?: #f)
            check-protocol-functions(?spec)
          end;
-         define test ?protocol-name ## "-protocol-variables-test" (allow-empty: #t)
+         define test ?protocol-name ## "-protocol-variables-test" (requires-assertions?: #f)
            check-protocol-variables(?spec)
          end;
-         define test ?protocol-name ## "-protocol-constants-test" (allow-empty: #t)
+         define test ?protocol-name ## "-protocol-constants-test" (requires-assertions?: #f)
            check-protocol-constants(?spec)
          end;
-         define test ?protocol-name ## "-protocol-macros-test" (allow-empty: #t)
+         define test ?protocol-name ## "-protocol-macros-test" (requires-assertions?: #f)
            check-protocol-macros(?spec)
          end;
          define suite ?protocol-name ## "-protocol-test-suite" ()

--- a/tests/specification.dylan
+++ b/tests/specification.dylan
@@ -35,7 +35,7 @@ define module-spec %testworks ()
   function show-progress (<test-runner>, false-or(<component>), false-or(<result>)) => ();
   function log-report-function (<result>, <stream>) => ();
   class <suite> (<component>);
-  function find-test (<string>, #"key", #"search-suite") => (false-or(<test>));
+  function find-runnable (<string>, #"key", #"search-suite") => (false-or(<runnable>));
   function null-report-function (<result>, <stream>) => ();
   function find-suite (<string>, #"key", #"search-suite") => (false-or(<suite>));
   class <component> (<object>);
@@ -62,8 +62,11 @@ define module-spec %testworks ()
   constant $test-log-footer :: <object>;
   function component-name (<component>) => (<string>);
   function do-results (<object>, <object>) => (#"rest");
-  class <test> (<component>);
-  function test-function (<test>) => (<function>);
+  abstract class <runnable> (<component>);
+  class <test> (<runnable>);
+  class <benchmark> (<runnable>);
+  function test-function (<runnable>) => (<function>);
+  function test-requires-assertions? (<runnable>) => (<boolean>);
   constant $failed :: <object>;
   function plural (<integer>) => (<string>);
   constant $default :: <object>;
@@ -72,7 +75,7 @@ define module-spec %testworks ()
   class <test-unit-result> (<test-result>, <unit-result>);
   instantiable class <tag> (<object>);
   class <result> (<object>);
-  function test-tags (<test>) => (<sequence>);
+  function test-tags (<runnable>) => (<sequence>);
   constant $test-log-header :: <object>;
   constant $verbose :: <object>;
   function result-reason (<result>) => (false-or(<string>));
@@ -200,9 +203,9 @@ define %testworks class-test <suite> ()
   //---*** Fill this in...
 end class-test <suite>;
 
-define %testworks function-test find-test ()
+define %testworks function-test find-runnable ()
   //---*** Fill this in...
-end function-test find-test;
+end function-test find-runnable;
 
 define %testworks function-test null-report-function ()
   //---*** Fill this in...
@@ -296,6 +299,14 @@ define %testworks class-test <test> ()
   //---*** Fill this in...
 end class-test <test>;
 
+define %testworks class-test <benchmark> ()
+  //---*** Fill this in...
+end class-test <benchmark>;
+
+define %testworks class-test <runnable> ()
+  //---*** Fill this in...
+end class-test <runnable>;
+
 define %testworks function-test test-function ()
   //---*** Fill this in...
 end function-test test-function;
@@ -351,6 +362,11 @@ end function-test result-reason;
 define %testworks function-test result-subresults ()
   //---*** Fill this in...
 end function-test result-subresults;
+
+define %testworks function-test test-requires-assertions? ()
+  //---*** Fill this in...
+end function-test test-requires-assertions?;
+
 
 // Module: testworks
 
@@ -462,6 +478,7 @@ define testworks macro-test check-equal-test ()
   //---*** Fill this in...
 end macro-test check-equal-test;
 
+
 define library-spec testworks ()
   module %testworks;
   module testworks;
@@ -469,6 +486,7 @@ define library-spec testworks ()
   suite testworks-assertion-macros-suite;
   suite testworks-results-suite;
   suite command-line-test-suite;
+  suite testworks-benchmarks-suite;
   test test-with-test-unit;
   test test-assertion-failure-continue;
   test test-many-assertions;

--- a/tests/testworks-test-suite.dylan
+++ b/tests/testworks-test-suite.dylan
@@ -276,6 +276,14 @@ define suite testworks-assertion-macros-suite ()
 end suite testworks-assertion-macros-suite;
 
 
+define benchmark basic-benchmark ()
+  "just exercise basic benchmark functionality"
+end;
+
+define suite testworks-benchmarks-suite ()
+  benchmark basic-benchmark;
+end;
+
 
 /// Verify the result objects
 
@@ -288,6 +296,10 @@ define test test-run-tests/test ()
                "run-tests returns $passed when passing");
   assert-true(instance?(test-results.result-subresults, <vector>),
               "run-tests sub-results are in a vector");
+
+  let bench-results = run-tests(runner, basic-benchmark);
+  assert-true(instance?(bench-results, <benchmark-result>),
+              "run-tests returns <benchmark-result> when running a <benchmark>");
 end test test-run-tests/test;
 
 define test test-run-tests/suite ()

--- a/utils.dylan
+++ b/utils.dylan
@@ -74,7 +74,7 @@ define method tags-match?
 end;
 
 define method tags-match?
-    (requested-tags :: <sequence>, test :: <test>)
+    (requested-tags :: <sequence>, test :: <runnable>)
  => (bool :: <boolean>)
   local method match (negated?)
           block (return)


### PR DESCRIPTION
Add back basic benchmark support.  Implemented via a 'benchmark' tag.
Replace --list-{tests,suites} with --list={tests,suites,benchmarks,all}.
