### PR TITLE
Output progress text more frequently.

### DIFF
--- a/run.dylan
+++ b/run.dylan
@@ -25,6 +25,7 @@ define method test-output
   let stream = runner-output-stream(*runner*);
   with-stream-locked (stream)
     apply(format, stream, format-string, format-args);
+    force-output(stream);
   end;
 end method test-output;
 


### PR DESCRIPTION
* run.dylan
  (test-output): Call force-output to make sure output is visible
   sooner rather than waiting for a buffer to flush.