### PR TITLE
testworks: Fix reporting support for benchmarks

### DIFF
--- a/results.dylan
+++ b/results.dylan
@@ -100,6 +100,11 @@ define method result-type-name
 end;
 
 define method result-type-name
+    (result :: <benchmark-result>) => (name :: <string>)
+  "Benchmark"
+end;
+
+define method result-type-name
     (result :: <check-result>) => (name :: <string>)
   "Check"
 end;


### PR DESCRIPTION
* results.dylan
  (result-type-name on ``<benchmark-result>``): New method to provide
   a reporting label for benchmark results.