### PR TITLE
Use <choice-option> in command line parser.

### DIFF
--- a/tests/test-command-line.dylan
+++ b/tests/test-command-line.dylan
@@ -4,8 +4,7 @@ Synopsis: Tests for command-line.dylan
 
 // Verify that command-line options create a <test-runner> correctly.
 define test test-make-runner-from-command-line ()
-  let args = list(list("--debug", debug-runner?, #t),
-                  list("--debug=no", debug-runner?, #f),
+  let args = list(list("--debug=no", debug-runner?, #f),
                   list("--debug=crashes", debug-runner?, #"crashes"),
                   list("--debug=failures", debug-runner?, #t));
   let dummy-component = make(<suite>,


### PR DESCRIPTION
Using ``<choice-option>`` results in better error reporting.

* ``command-line.dylan``
  (``general``): Move some constants to the top of the file before
    they are used.
  (``parse-args``): Switch from ``<optional-parameter-option>`` and
    ``<parameter-option>`` to ``<choice-option>``.
  (``make-runner-from-command-line``): Remove extraneous error handling
    now that ``<choice-option>`` is handling it.

* ``tests/test-command-line.dylan``
  (``test-make-runner-from-command-line``): Remove test of bare ``--debug``
    for now as it doesn't work any longer.