### PR TITLE
testworks: Support passing options to tests

### DIFF
--- a/command-line.dylan
+++ b/command-line.dylan
@@ -147,6 +147,16 @@ define function make-runner-from-command-line
                     report: report,
                     progress: if (progress = $none) #f else progress end,
                     tags: parse-tags(get-option-value(parser, "tag")));
+
+  for (option in parser.positional-options)
+    let split = find-key(option, curry(\==, '='));
+    if (split)
+      let key = copy-sequence(option, end: split);
+      let value = copy-sequence(option, start: split + 1);
+      runner.runner-options[key] := value;
+    end if;
+  end for;
+
   let components = find-components(get-option-value(parser, "suite"),
                                    get-option-value(parser, "test"));
   let start-suite = select (components.size)

--- a/documentation/users-guide/source/reference.rst
+++ b/documentation/users-guide/source/reference.rst
@@ -391,5 +391,25 @@ Test Execution
    :class:`<test-runner>` based on the command-line options and then
    calls :func:`run-tests` with the runner and *suite-or-test*.
 
+.. function:: test-option
+
+   Return an option value passed on the test-application command line.
+
+   :signature: test-option *name* #key *default* => *value*
+   :parameter name: An instance of type :drm:`<string>`.
+   :parameter #key default: An instance of type :drm:`<string>`.
+   :value value: An instance of type :drm:`<string>`.
+
+   :description:
+
+   Returns an option value passed to the test on the test application
+   command line, in the form ``*name*=*value*``. If no option value
+   was given, the *default* value is returned if one was supplied,
+   otherwise an error is signalled.
+
+   This feature allows information about external resources, such as
+   path names of reference data files, or the hostname of a test
+   database server, to be supplied on the command line of the test
+   application and retrieved by the test.
 
 .. TODO(cgay): document the remaining exported names.

--- a/library.dylan
+++ b/library.dylan
@@ -67,6 +67,9 @@ define module testworks
   create
     test-output;
 
+  // Options
+  create
+    test-option;
 end module testworks;
 
 

--- a/run.dylan
+++ b/run.dylan
@@ -51,6 +51,8 @@ define open class <test-runner> (<object>)
       = colorize-stream(*standard-output*),
     init-keyword: output-stream:;
 
+  constant slot runner-options :: <string-table> = make(<string-table>),
+    init-keyword: options:;
 end class <test-runner>;
 
 
@@ -321,3 +323,19 @@ define method show-progress
     test-output("\n  %s: [%s]\n  ", result.result-name, reason);
   end;
 end method show-progress;
+
+/// Test options
+
+define function test-option
+    (name :: <string>, #key default = unsupplied())
+ => (option-value :: <string>);
+  let option-value
+    = element(*runner*.runner-options, name, default: unfound());
+  if (found?(option-value))
+    option-value
+  elseif (supplied?(default))
+    default
+  else
+    error("No value for test option %s was supplied", name)
+  end if
+end function;

--- a/tests/specification.dylan
+++ b/tests/specification.dylan
@@ -100,6 +100,7 @@ define module-spec testworks ()
   macro-test suite-definer-test;
   function runner-skip (<test-runner>) => (<sequence>);
   function test-output (<string>, #"rest") => ();
+  function test-option (<string>, #"key", #"default") => (<string>);
   macro-test with-test-unit-test;
   macro-test test-definer-test;
   function debug-runner? (<test-runner>) => (<object>);
@@ -433,6 +434,13 @@ end function-test runner-skip;
 define testworks function-test test-output ()
   //---*** Fill this in...
 end function-test test-output;
+
+define testworks function-test test-option ()
+  //---*** Fill this in...
+  check-instance?("test-option returns a <string>",
+                  <string>,
+                  test-option("foo", default: "bleah"));
+end function-test test-option;
 
 define testworks macro-test with-test-unit-test ()
   //---*** Fill this in...


### PR DESCRIPTION
Sometimes test functions need to have information about external
entities, such as the directory path of test or reference data files, or
the hostname of a test database server. This commit allows this sort of
information to be supplied on the command line of the test application.
