### PR TITLE
Add expected-failure support.

### DIFF
--- a/coloring.dylan
+++ b/coloring.dylan
@@ -16,6 +16,10 @@ define constant $failed-attributes
   = text-attributes(foreground: $color-red);
 define constant $crashed-attributes
   = text-attributes(foreground: $color-red);
+define constant $expected-failure-attributes
+  = text-attributes(foreground: $color-cyan);
+define constant $unexpected-success-attributes
+  = text-attributes(foreground: $color-red);
 define constant $component-name-attributes
   = text-attributes(intensity: $bright-intensity);
 define constant $total-attributes
@@ -31,6 +35,8 @@ define function result-status-to-attributes
     $failed => $failed-attributes;
     $crashed => $crashed-attributes;
     $skipped => $skipped-attributes;
+    $expected-failure => $expected-failure-attributes;
+    $unexpected-success => $unexpected-success-attributes;
     $not-implemented => $not-implemented-attributes;
     otherwise =>
       error("Unrecognized test result status: %=.  This is a testworks bug.",

--- a/components.dylan
+++ b/components.dylan
@@ -27,6 +27,8 @@ end class <suite>;
 define abstract class <runnable> (<component>)
   constant slot test-function :: <function>,
     required-init-keyword: function:;
+  constant slot %expected-failure? :: type-union(<boolean>, <function>) = #f,
+    init-keyword: expected-failure?:;
   // Benchmarks don't require assertions.  Needs to be an instance
   // variable, not a bare method, because testworks-specs
   // auto-generated tests often don't get filled in.  I want to kill
@@ -48,6 +50,13 @@ define method make
   end;
   apply(next-method, class, tags: tags, args)
 end method make;
+
+define method expected-failure? (r :: <runnable>)
+  select (r.%expected-failure? by instance?)
+    <boolean> => r.%expected-failure?;
+    <function> => r.%expected-failure?();
+  end select
+end method expected-failure?;
 
 define class <test> (<runnable>)
 end;

--- a/documentation/users-guide/source/reference.rst
+++ b/documentation/users-guide/source/reference.rst
@@ -46,9 +46,12 @@ Suites, Tests, and Benchmarks
 
    Define a new test.
 
-   :signature: define test *test-name* (#key *description, tags*) *body* end
+   :signature: define test *test-name* (#key *description, expected-failure?, tags*) *body* end
    :parameter test-name: Name of the test; a Dylan variable name.
    :parameter #key description: A string describing the purpose of the test.
+   :parameter #key expected-failure?: An instance of either :drm:`<boolean>` or
+      :drm:`<function>`. This indicates whether or not the test is expected to
+      fail.
    :parameter #key tags: A list of strings to tag this test.
 
    Tests may contain arbitrary code, plus any number of assertions.
@@ -56,6 +59,12 @@ Suites, Tests, and Benchmarks
    assertions in the test will still be executed.  If code outside of
    an assertion signals an error, the test is marked as "crashed" and
    remaining assertions are skipped.
+
+   If *expected-failure?* is set to ``#t`` or a function that when executed
+   returns ``#t``, then the test will be expected to fail. Such a failure
+   will be treated as a successful test run. If the test passes rather than
+   failing, then that will be considered a test failure. This option has
+   no effect on tests which are *not implemented* or which have *crashed*.
 
    *tags* provide a way to select or filter out specific tests during
    a test run.  The Testworks command-line (provided by
@@ -66,14 +75,23 @@ Suites, Tests, and Benchmarks
 
    Define a new benchmark.
 
-   :signature: define benchmark *name* (#key *description, tags*) *body* end
+   :signature: define benchmark *name* (#key *description, expected-failure?, tags*) *body* end
    :parameter name: Name of the benchmark; a Dylan variable name.
    :parameter #key description: A string describing the purpose of the benchmark.
+   :parameter #key expected-failure?: An instance of either :drm:`<boolean>` or
+      :drm:`<function>`. This indicates whether or not the test is expected to
+      fail.
    :parameter #key tags: A list of strings to tag this benchmark.
 
    Benchmarks may contain arbitrary code and may use assertions,
    although that isn't required.  If the benchmark signals an error it
    is marked as "crashed".
+
+   If *expected-failure?* is set to ``#t`` or a function that when executed
+   returns ``#t``, then the test will be expected to fail. Such a failure
+   will be treated as a successful test run. If the test passes rather than
+   failing, then that will be considered a test failure. This option has
+   no effect on tests which are *not implemented* or which have *crashed*.
 
    *tags* provide a way to select or filter out specific tests during
    a test run.  The Testworks command-line (provided by

--- a/documentation/users-guide/source/usage.rst
+++ b/documentation/users-guide/source/usage.rst
@@ -145,7 +145,7 @@ assertions. Each test is part of a suite.  Use the
 
 .. code-block:: dylan
 
-    define test NAME (#key DESCRIPTION, TAGS)
+    define test NAME (#key DESCRIPTION, EXPECTED-FAILURE?, TAGS)
       BODY
     end;
 
@@ -195,6 +195,28 @@ this will skip both of the above tests::
 
 Negative tags take precedence, so ``--tag=huge --tag=-verbose`` will
 run ``my-test-2`` and skip ``my-test-3``.
+
+If the test is expected to fail, or fails under some conditions, Testworks
+can be made aware of this:
+
+.. code-block:: dylan
+
+    define test failing-test (expected-failure?: #t)
+      assert-true(#f);
+    end test;
+
+    define test fails-on-windows
+        (expected-failure?: method () $os-name = #"win32" end)
+      if ($os-name = #"win32")
+        assert-false(#t);
+      else
+        assert-true(#t);
+      end if;
+    end test;
+
+A test that is expected to fail and then fails will be considered to
+be a passing test. If the test succeeds unexpectedly, it will be considered
+a failing test.
 
 Benchmarks
 ----------

--- a/library.dylan
+++ b/library.dylan
@@ -132,6 +132,7 @@ define module %testworks
     <result-status>,
     result-status,
       $passed, $failed, $skipped, $not-implemented, $crashed,
+      $expected-failure, $unexpected-success,
     result-seconds,
     result-microseconds,
     result-time,

--- a/reports.dylan
+++ b/reports.dylan
@@ -47,6 +47,10 @@ define method count-results
            not-executed := not-executed + 1;
          $not-implemented =>
            not-implemented := not-implemented + 1;
+         $expected-failure =>
+           passes := passes + 1;
+         $unexpected-success =>
+           failures := failures + 1;
          $crashed =>
            crashes := crashes + 1;
          otherwise =>

--- a/results.dylan
+++ b/results.dylan
@@ -10,10 +10,14 @@ define constant $passed = #"passed";
 define constant $failed = #"failed";
 define constant $crashed = #"crashed";
 define constant $skipped = #"skipped";
+define constant $expected-failure = #"expected-failure";
+define constant $unexpected-success = #"unexpected-success";
 define constant $not-implemented  = #"nyi";
 
 define constant <result-status>
-  = one-of($passed, $failed, $crashed, $skipped, $not-implemented);
+  = one-of($passed, $failed, $crashed, $skipped,
+           $expected-failure, $unexpected-success,
+           $not-implemented);
 
 // It looks like this and testworks-reports:parse-status are meant to
 // be inverses.
@@ -24,6 +28,8 @@ define method status-name
     $failed => "failed";
     $crashed => "crashed";
     $skipped => "skipped";
+    $expected-failure => "failed as expected";
+    $unexpected-success => "unexpectedly succeeded";
     $not-implemented => "not implemented";
     otherwise =>
       error("Unrecognized test result status: %=.  This is a testworks bug.",

--- a/run.dylan
+++ b/run.dylan
@@ -157,7 +157,7 @@ define method execute-component
             $not-implemented;
           every?(method (subresult)
                    let status = subresult.result-status;
-                   status = $passed | status = $skipped
+                   status = $passed | status = $skipped | status = $expected-failure
                  end,
                  subresults) =>
             $passed;
@@ -202,9 +202,17 @@ define method execute-component
                    result.result-status == $passed
                  end,
                  subresults) =>
-            $passed;
+            if (test.expected-failure?)
+              $unexpected-success
+            else
+              $passed
+            end if;
           otherwise =>
-            $failed;
+            if (test.expected-failure?)
+              $expected-failure
+            else
+              $failed
+            end if;
         end
       end;
   values(subresults, status, reason, seconds, microseconds, bytes)

--- a/tests/testworks-test-suite.dylan
+++ b/tests/testworks-test-suite.dylan
@@ -326,9 +326,58 @@ define test test-with-test-unit ()
   end;
 end test test-with-test-unit;
 
+define test test-expected-failure-always(expected-failure?: #t)
+  assert-true(#f);
+end test;
+
+define test test-expected-failure-maybe(expected-failure?: method () #t end)
+  assert-true(#f);
+end test;
+
+define test test-unexpected-success(expected-failure?: #t)
+  assert-true(#t);
+end test;
+
+define suite expected-failure-suite ()
+  test test-expected-failure-always;
+  test test-expected-failure-maybe;
+end suite;
+
+define suite unexpected-success-suite ()
+  test test-unexpected-success;
+end suite;
+
+define test test-run-tests-expect-failure/suite ()
+  let suite-to-check = expected-failure-suite;
+  let runner = make(<test-runner>, progress: #f);
+  let suite-results = run-tests(runner, suite-to-check);
+  assert-equal($passed, suite-results.result-status);
+
+  let suite-to-check = unexpected-success-suite;
+  let suite-results = run-tests(runner, suite-to-check);
+  assert-equal($failed, suite-results.result-status);
+end test test-run-tests-expect-failure/suite;
+
+define test test-run-tests-expect-failure/test ()
+  let test-to-check = test-expected-failure-always;
+  let runner = make(<test-runner>, progress: #f);
+  let test-results = run-tests(runner, test-to-check);
+  assert-equal($expected-failure, test-results.result-status);
+
+  let test-to-check = test-expected-failure-maybe;
+  let test-results = run-tests(runner, test-to-check);
+  assert-equal($expected-failure, test-results.result-status);
+
+  let test-to-check = test-unexpected-success;
+  let test-results = run-tests(runner, test-to-check);
+  assert-equal($unexpected-success, test-results.result-status);
+end test test-run-tests-expect-failure/test;
+
 define suite testworks-results-suite ()
   test test-run-tests/suite;
   test test-run-tests/test;
+  test test-run-tests-expect-failure/suite;
+  test test-run-tests-expect-failure/test;
 end;
 
 // Make sure that if one assertion fails the remaining assertions


### PR DESCRIPTION
It is useful to be able to note that a test is expected to fail
and to note when it unexpectedly succeeds.  This will be useful
for the Dylan test suites where we have some long-standing failures
that can be flagged as expecting to fail so that we will notice
new failures or other changes in the status of tests.

Fixes bug #72.

* components.dylan
  (``%expected-failure?``): New slot on ``<runnable>``, parent class for
    both ``<test>`` and ``<benchmark>``.
  (``expected-failure?``): New method to see if a test is expected
    to fail. This inspects ``%expected-failure?`` and evaluates the
    method if there is one.

* results.dylan
  (``$expected-failure``, ``$unexpected-success``): New status values.
  (``<result-status>``): Update to include new status values.
  (``status-name``): Update to handle new status values.

* reports.dylan
  (``count-results``): Count ``$expected-failure`` as a pass, ``$unexpected-success``
    as a failure.

* coloring.dylan
  (``$expected-failure-attributes``, ``$unexpected-success-attributes``): New
    text attributes.
  (``result-status-to-attributes``): Map new status values to new text attributes.

* run.dylan
  (``execute-component on <suite>``): Count an ``$expected-failure`` result as
    a passing result.
  (``execute-component on <test>``): Check ``expected-failure?`` to handle
    ``$passed`` and ``$failed`` correctly.

* library.dylan
  (``module %testworks``): Export ``$expected-failure`` and ``$unexpected-success``.

* documentation/users-guide/source/reference.rst
  (``test-definer``, ``benchmark-definer``): Update to discuss expected-failure?.

* documentation/users-guide/source/usage.rst
  (Tests): Update to discuss expected failures.

* tests/testworks-test-suite.dylan: Update to test expected failure and
  unexpected success scenarios.