### PR TITLE
assert-instance?, assert-not-instance?

### DIFF
--- a/assertions.dylan
+++ b/assertions.dylan
@@ -152,12 +152,43 @@ define macro check-instance?
     do-check-instance?(method () ?check-name end,
                        method ()
                          values(?type, ?value, ?"value")
-                       end)
+                       end,
+                       #f)
   }
 end macro check-instance?;
 
+define macro assert-instance?
+  { assert-instance? (?type:expression, ?value:expression)
+  } => {
+    assert-instance? (?type, ?value, "instance?(" ?"type" ", " ?"value" ")")
+  }
+  { assert-instance? (?type:expression, ?value:expression, ?description:expression)
+  } => {
+    do-check-instance?(method () ?description end,
+                       method ()
+                         values(?type, ?value, ?"value")
+                       end,
+                       #f)
+  }
+end macro assert-instance?;
+
+define macro assert-not-instance?
+  { assert-not-instance? (?type:expression, ?value:expression)
+  } => {
+    assert-not-instance? (?type, ?value, "instance?(" ?"type" ", " ?"value" ")")
+  }
+  { assert-not-instance? (?type:expression, ?value:expression, ?description:expression)
+  } => {
+    do-check-instance?(method () ?description end,
+                       method ()
+                         values(?type, ?value, ?"value")
+                       end,
+                       #t)
+  }
+end macro assert-not-instance?;
+
 define function do-check-instance?
-    (get-name :: <function>, get-arguments :: <function>)
+    (get-name :: <function>, get-arguments :: <function>, negate? :: <boolean>)
  => (status :: <result-status>)
   let phase = "evaluating check name";
   let name = #f;
@@ -176,10 +207,10 @@ define function do-check-instance?
     name := get-name();
     phase := "evaluating check arguments";
     let (type :: <type>, value, value-expr :: <string>) = get-arguments();
-    phase := format-to-string("checking if %= is an instance of %s",
-                              value-expr, type);
+    phase := format-to-string("checking if %= is %=an instance of %s",
+                              value-expr, if (negate?) "not " else "" end, type);
     let (status, reason)
-      = if (instance?(value, type))
+      = if (instance?(value, type) ~= negate?)
           $passed
         else
           values($failed,

--- a/documentation/users-guide/source/reference.rst
+++ b/documentation/users-guide/source/reference.rst
@@ -118,6 +118,8 @@ These are the available assertion macros:
   * :macro:`assert-not-equal`
   * :macro:`assert-signals`
   * :macro:`assert-no-errors`
+  * :macro:`assert-instance?`
+  * :macro:`assert-not-instance?`
 
 .. macro:: assert-true
 
@@ -264,6 +266,52 @@ These are the available assertion macros:
                           "hairy logic completes without error")
 
 
+.. macro:: assert-instance?
+
+   Assert that the result of an expression is an instance of a given type.
+
+   :signature: assert-instance? *type* *expression* [ *description* ]
+
+   :parameter type: The expected type.
+   :parameter expression: An expression.
+   :parameter description: A description of what the assertion tests.
+      This should be stated in positive form, such as "two is less
+      than three".  If no description is supplied one will be
+      automatically generated based on the text of the expression.
+
+   :example:
+
+     .. code-block:: dylan
+
+       assert-instance?(<type>, subclass(<string>));
+
+       assert-instance?(<type>, subclass(<string>),
+                        "subclass returns type");
+
+
+.. macro:: assert-not-instance?
+
+   Assert that the result of an expression is **not** an instance of a given class.
+
+   :signature: assert-not-instance? *type* *expression* [ *description* ]
+
+   :parameter type: The type.
+   :parameter expression: An expression.
+   :parameter description: A description of what the assertion tests.
+      This should be stated in positive form, such as "two is less
+      than three".  If no description is supplied one will be
+      automatically generated based on the text of the expression.
+
+   :example:
+
+     .. code-block:: dylan
+
+       assert-not-instance?(limited(<integer>, min: 0), -1);
+
+       assert-not-instance?(limited(<integer>, min: 0), -1,
+                            "values below lower bound are not instances");
+
+
 Checks
 ------
 
@@ -353,12 +401,12 @@ These are the available checks:
 
 .. macro:: check-instance?
 
-   Check that the result of an expression is an instance of a given class.
+   Check that the result of an expression is an instance of a given type.
 
    :signature: check-instance? *name* *type* *expression*
 
    :parameter name: An instance of ``<string>``.
-   :parameter type: The expected class.
+   :parameter type: The expected type.
    :parameter expression: An expression.
 
    :example:

--- a/documentation/users-guide/source/usage.rst
+++ b/documentation/users-guide/source/usage.rst
@@ -117,6 +117,8 @@ assertion macros:
   * :func:`assert-not-equal`
   * :func:`assert-signals`
   * :func:`assert-no-errors`
+  * :func:`assert-instance?`
+  * :func:`assert-not-instance?`
 
 Each of these takes an optional description string, after the required
 arguments, which will be displayed if the assertion fails.  If the

--- a/library.dylan
+++ b/library.dylan
@@ -53,6 +53,8 @@ define module testworks
     assert-not-equal,
     assert-signals,
     assert-no-errors,
+    assert-instance?,
+    assert-not-instance?,
     assert-true,
     assert-false;
 

--- a/tests/specification.dylan
+++ b/tests/specification.dylan
@@ -83,7 +83,9 @@ define module-spec %testworks ()
 end module-spec %testworks;
 
 define module-spec testworks ()
+  macro-test assert-instance?-test;
   macro-test check-instance?-test;
+  macro-test assert-not-instance?-test;
   macro-test check-no-condition-test;
   macro-test assert-equal-test;
   macro-test check-no-errors-test;
@@ -371,9 +373,17 @@ end function-test test-requires-assertions?;
 
 // Module: testworks
 
+define testworks macro-test assert-instance?-test ()
+  //---*** Fill this in...
+end macro-test assert-instance?-test;
+
 define testworks macro-test check-instance?-test ()
   //---*** Fill this in...
 end macro-test check-instance?-test;
+
+define testworks macro-test assert-not-instance?-test ()
+  //---*** Fill this in...
+end macro-test assert-not-instance?-test;
 
 define testworks macro-test check-no-condition-test ()
   //---*** Fill this in...

--- a/tests/testworks-test-suite.dylan
+++ b/tests/testworks-test-suite.dylan
@@ -160,18 +160,54 @@ define test testworks-check-instance?-test ()
                  check-instance?($internal-check-name, <integer>, 1)
                end,
                $passed,
-               "check-instance?(1, <integer>) passes");
+               "check-instance?(<integer>, 1) passes");
   assert-equal(without-recording ()
                  check-instance?($internal-check-name, <string>, 1)
                end,
                $failed,
-               "check-instance?(1, <string>) fails");
+               "check-instance?(<string>, 1) fails");
   assert-equal(without-recording ()
                  check-instance?($internal-check-name, <integer>, test-error())
                end,
                $crashed,
                "check-instance? of error crashes");
 end test testworks-check-instance?-test;
+
+define test testworks-assert-instance?-test ()
+  assert-equal(without-recording ()
+                 assert-instance?(<integer>, 1)
+               end,
+               $passed,
+               "assert-instance?(<integer>, 1) passes");
+  assert-equal(without-recording ()
+                 assert-instance?(<string>, 1)
+               end,
+               $failed,
+               "assert-instance?(<string>, 1) fails");
+  assert-equal(without-recording ()
+                 assert-instance?(<integer>, test-error())
+               end,
+               $crashed,
+               "assert-instance? of error crashes");
+end test testworks-assert-instance?-test;
+
+define test testworks-assert-not-instance?-test ()
+  assert-equal(without-recording ()
+                 assert-not-instance?(<string>, 1)
+               end,
+               $passed,
+               "assert-not-instance?(<string>, 1) passes");
+  assert-equal(without-recording ()
+                 assert-not-instance?(<integer>, 1)
+               end,
+               $failed,
+               "assert-not-instance?(<integer>, 1) fails");
+  assert-equal(without-recording ()
+                 assert-not-instance?(<integer>, test-error())
+               end,
+               $crashed,
+               "assert-not-instance? of error crashes");
+end test testworks-assert-not-instance?-test;
 
 define test testworks-check-condition-test ()
   begin
@@ -271,6 +307,8 @@ define suite testworks-assertion-macros-suite ()
   test testworks-assert-equal-test;
   test testworks-assert-equal-failure-detail;
   test testworks-assert-not-equal-test;
+  test testworks-assert-instance?-test;
+  test testworks-assert-not-instance?-test;
   test testworks-assert-signals-test;
   test testworks-assert-no-errors-test;
 end suite testworks-assertion-macros-suite;


### PR DESCRIPTION
This brings ``assert-instance?`` and ``assert-not-instance?`` macros to the newer
assert-based macros. These can be used to get better test failure output
when an assertion fails (rather than ``assert-true(instance?(...))`` or
``assert-false(instance?(...))``).

* assertions.dylan
  (``do-check-instance?``): Add ``negate?`` flag to handle ``~instance?`` as well.
  (``check-instance?``): Pass ``#f`` for ``negate?`` to ``do-check-instance?``.
  (``assert-instance?``, ``assert-not-instance?``): New macros.

* library.dylan
  (module ``testworks``): Export ``assert-instance?``, ``assert-not-instance?``.

* documentation/users-guide/source/reference.rst
  (``assert-instance?``, ``assert-not-instance?``): Document.
  (``check-instance?``): Correct terminology: type, not class.

* documentation/users-guide/source/usage.rst
  (Assertions): Link to new assertions.

* tests/specification.dylan
  (module-spec ``testworks``): Mention new assertions and stub tests.

* tests/testworks-test-suite.dylan
  (``testworks-assert-instance?-test``,
   ``testworks-assert-not-instance-test``): Test new assertions. We test these
     here to be consistent with the other assertion tests. In the future,
     this could move to the testworks specifications tests.
  (``testworks-assertion-macros-suite``): Run the new tests.