### PR TITLE
Cleanup do-check-* functions

### DIFF
--- a/assertions.dylan
+++ b/assertions.dylan
@@ -189,7 +189,7 @@ end macro assert-not-instance?;
 
 define function do-check-instance?
     (get-name :: <function>, get-arguments :: <function>, negate? :: <boolean>)
- => (status :: <result-status>)
+ => (result :: <result>)
   let phase = "evaluating check name";
   let name = #f;
   block (return)
@@ -198,10 +198,9 @@ define function do-check-instance?
             if (debug?())
               next-handler()  // decline to handle it
             else
-              record-check(name | "*** Invalid check name ***",
-                           $crashed,
-                           format-to-string("Error %s: %s", phase, condition));
-              return($crashed);
+              return(record-check(name | "*** Invalid check name ***",
+                                  $crashed,
+                                  format-to-string("Error %s: %s", phase, condition)))
             end;
           end method;
     name := get-name();
@@ -217,8 +216,7 @@ define function do-check-instance?
                  format-to-string("%s (from expression %=) is not an instance of %s.",
                                   value, value-expr, type))
         end;
-    record-check(name, status, reason);
-    status
+    record-check(name, status, reason)
   end block
 end function do-check-instance?;
 
@@ -247,7 +245,7 @@ end macro assert-true;
 
 define function do-check-true
     (get-name :: <function>, get-arguments :: <function>)
- => (status :: <result-status>)
+ => (result :: <result>)
   let phase = "evaluating assertion description";
   let name = #f;
   block (return)
@@ -256,10 +254,9 @@ define function do-check-true
             if (debug?())
               next-handler()  // decline to handle it
             else
-              record-check(name | "*** Invalid description ***",
-                           $crashed,
-                           format-to-string("Error %s: %s", phase, condition));
-              return($crashed);
+              return(record-check(name | "*** Invalid description ***",
+                                  $crashed,
+                                  format-to-string("Error %s: %s", phase, condition)))
             end;
           end method;
     name := get-name();
@@ -274,8 +271,7 @@ define function do-check-true
                  format-to-string("expression %= evaluates to #f, not a true value.",
                                   value-expr))
         end;
-    record-check(name, status, reason);
-    status
+    record-check(name, status, reason)
   end block
 end function do-check-true;
 
@@ -306,7 +302,7 @@ end macro assert-false;
 
 define function do-check-false
     (get-name :: <function>, get-arguments :: <function>)
- => (status :: <result-status>)
+ => (result :: <result>)
   let phase = "evaluating assertion description";
   let name = #f;
   block (return)
@@ -315,10 +311,9 @@ define function do-check-false
             if (debug?())
               next-handler()  // decline to handle it
             else
-              record-check(name | "*** Invalid description ***",
-                           $crashed,
-                           format-to-string("Error %s: %s", phase, condition));
-              return($crashed);
+              return(record-check(name | "*** Invalid description ***",
+                                  $crashed,
+                                  format-to-string("Error %s: %s", phase, condition)))
             end;
           end method;
     name := get-name();
@@ -333,8 +328,7 @@ define function do-check-false
                  format-to-string("expression %= does not evaluate to #f.",
                                   value-expr))
         end;
-    record-check(name, status, reason);
-    status
+    record-check(name, status, reason)
   end block
 end function do-check-false;
 
@@ -366,7 +360,7 @@ end macro assert-signals;
 
 define function do-check-condition
     (get-name :: <function>, get-arguments :: <function>)
- => (status :: <result-status>)
+ => (result :: <result>)
   let phase = "evaluating assertion description";
   let name = #f;
   block (return)
@@ -375,10 +369,9 @@ define function do-check-condition
             if (debug?())
               next-handler()  // decline to handle it
             else
-              record-check(name | "*** Invalid description ***",
-                           $crashed,
-                           format-to-string("Error %s: %s", phase, condition));
-              return($crashed);
+              return(record-check(name | "*** Invalid description ***",
+                                  $crashed,
+                                  format-to-string("Error %s: %s", phase, condition)))
             end;
           end method;
     name := get-name();
@@ -400,8 +393,7 @@ define function do-check-condition
                                              "The error was: %s",
                                            ex.object-class, condition-class, ex))
         end;
-    record-check(name, status, reason);
-    status
+    record-check(name, status, reason)
   end block
 end function do-check-condition;
 

--- a/assertions.dylan
+++ b/assertions.dylan
@@ -190,7 +190,7 @@ end macro assert-not-instance?;
 define function do-check-instance?
     (get-name :: <function>, get-arguments :: <function>, negate? :: <boolean>)
  => (result :: <result>)
-  let phase = "evaluating check name";
+  let phase = "evaluating assertion description";
   let name = #f;
   block (return)
     let handler <serious-condition>
@@ -198,13 +198,13 @@ define function do-check-instance?
             if (debug?())
               next-handler()  // decline to handle it
             else
-              return(record-check(name | "*** Invalid check name ***",
+              return(record-check(name | "*** Invalid description ***",
                                   $crashed,
                                   format-to-string("Error %s: %s", phase, condition)))
             end;
           end method;
     name := get-name();
-    phase := "evaluating check arguments";
+    phase := "evaluating assertion expressions";
     let (type :: <type>, value, value-expr :: <string>) = get-arguments();
     phase := format-to-string("checking if %= is %=an instance of %s",
                               value-expr, if (negate?) "not " else "" end, type);

--- a/tests/testworks-test-suite.dylan
+++ b/tests/testworks-test-suite.dylan
@@ -51,17 +51,17 @@ end test testworks-check-test;
 
 define test testworks-check-true-test ()
   assert-equal(without-recording ()
-                 check-true($internal-check-name, #t)
+                 result-status(check-true($internal-check-name, #t))
                end,
                $passed,
                "check-true(#t) passes");
   assert-equal(without-recording ()
-                 check-true($internal-check-name, #f)
+                 result-status(check-true($internal-check-name, #f))
                end,
                $failed,
                "check-true(#f) fails");
   assert-equal(without-recording ()
-                 check-true($internal-check-name, test-error())
+                 result-status(check-true($internal-check-name, test-error()))
                end,
                $crashed,
                "check-true of error crashes");
@@ -70,24 +70,33 @@ end test testworks-check-true-test;
 define test testworks-assert-true-test ()
   assert-true(#t);
   assert-true(#t, "#t is true with description");
-  assert-equal($passed, without-recording () assert-true(#t) end);
-  assert-equal($failed, without-recording () assert-true(#f) end);
-  assert-equal($crashed, without-recording () assert-true(test-error()) end);
+  assert-equal($passed,
+               without-recording ()
+                 result-status(assert-true(#t))
+               end);
+  assert-equal($failed,
+               without-recording ()
+                 result-status(assert-true(#f))
+               end);
+  assert-equal($crashed,
+               without-recording ()
+                 result-status(assert-true(test-error()))
+               end);
 end test testworks-assert-true-test;
 
 define test testworks-check-false-test ()
   assert-equal(without-recording ()
-                 check-false($internal-check-name, #t)
+                 result-status(check-false($internal-check-name, #t))
                end,
                $failed,
                "check-false(#t) fails");
   assert-equal(without-recording ()
-                 check-false($internal-check-name, #f)
+                 result-status(check-false($internal-check-name, #f))
                end,
                $passed,
                "check-false(#f) passes");
   assert-equal(without-recording ()
-                 check-false($internal-check-name, test-error())
+                 result-status(check-false($internal-check-name, test-error()))
                end,
                $crashed,
                "check-false of error crashes");
@@ -96,9 +105,18 @@ end test testworks-check-false-test;
 define test testworks-assert-false-test ()
   assert-false(#f);
   assert-false(#f, "#f is false with description");
-  assert-equal($failed, without-recording () assert-false(#t) end);
-  assert-equal($passed, without-recording () assert-false(#f) end);
-  assert-equal($crashed, without-recording () assert-false(test-error()) end);
+  assert-equal($failed,
+               without-recording ()
+                 result-status(assert-false(#t))
+               end);
+  assert-equal($passed,
+               without-recording ()
+                 result-status(assert-false(#f))
+               end);
+  assert-equal($crashed,
+               without-recording ()
+                 result-status(assert-false(test-error()))
+               end);
 end test testworks-assert-false-test;
 
 define test testworks-check-equal-test ()
@@ -136,38 +154,58 @@ end test testworks-assert-equal-failure-detail;
 define test testworks-assert-equal-test ()
   assert-equal(8, 8);
   assert-equal(8, 8, "8 = 8 with description");
-  assert-equal($passed, without-recording () result-status(assert-equal(1, 1)) end);
-  assert-equal($passed, without-recording () result-status(assert-equal("1", "1")) end);
-  assert-equal($failed, without-recording () result-status(assert-equal(1, 2)) end);
-  assert-equal($crashed, without-recording ()
-                           result-status(assert-equal(1, test-error()))
-                         end);
+  assert-equal($passed,
+               without-recording ()
+                 result-status(assert-equal(1, 1))
+               end);
+  assert-equal($passed,
+               without-recording ()
+                 result-status(assert-equal("1", "1"))
+               end);
+  assert-equal($failed,
+               without-recording ()
+                 result-status(assert-equal(1, 2))
+               end);
+  assert-equal($crashed,
+               without-recording ()
+                 result-status(assert-equal(1, test-error()))
+               end);
 end test testworks-assert-equal-test;
 
 define test testworks-assert-not-equal-test ()
   assert-not-equal(8, 9);
   assert-not-equal(8, 9, "8 ~= 9 with description");
-  assert-equal($passed, without-recording () result-status(assert-not-equal(1, 2)) end);
-  assert-equal($passed, without-recording () result-status(assert-not-equal("1", "2")) end);
-  assert-equal($failed, without-recording () result-status(assert-not-equal(1, 1)) end);
-  assert-equal($crashed, without-recording ()
-                           result-status(assert-not-equal(1, test-error()))
-                         end);
+  assert-equal($passed,
+               without-recording ()
+                 result-status(assert-not-equal(1, 2))
+               end);
+  assert-equal($passed,
+               without-recording ()
+                 result-status(assert-not-equal("1", "2"))
+               end);
+  assert-equal($failed,
+               without-recording ()
+                 result-status(assert-not-equal(1, 1))
+               end);
+  assert-equal($crashed,
+               without-recording ()
+                 result-status(assert-not-equal(1, test-error()))
+               end);
 end test testworks-assert-not-equal-test;
 
 define test testworks-check-instance?-test ()
   assert-equal(without-recording ()
-                 check-instance?($internal-check-name, <integer>, 1)
+                 result-status(check-instance?($internal-check-name, <integer>, 1))
                end,
                $passed,
                "check-instance?(<integer>, 1) passes");
   assert-equal(without-recording ()
-                 check-instance?($internal-check-name, <string>, 1)
+                 result-status(check-instance?($internal-check-name, <string>, 1))
                end,
                $failed,
                "check-instance?(<string>, 1) fails");
   assert-equal(without-recording ()
-                 check-instance?($internal-check-name, <integer>, test-error())
+                 result-status(check-instance?($internal-check-name, <integer>, test-error()))
                end,
                $crashed,
                "check-instance? of error crashes");
@@ -175,17 +213,17 @@ end test testworks-check-instance?-test;
 
 define test testworks-assert-instance?-test ()
   assert-equal(without-recording ()
-                 assert-instance?(<integer>, 1)
+                 result-status(assert-instance?(<integer>, 1))
                end,
                $passed,
                "assert-instance?(<integer>, 1) passes");
   assert-equal(without-recording ()
-                 assert-instance?(<string>, 1)
+                 result-status(assert-instance?(<string>, 1))
                end,
                $failed,
                "assert-instance?(<string>, 1) fails");
   assert-equal(without-recording ()
-                 assert-instance?(<integer>, test-error())
+                 result-status(assert-instance?(<integer>, test-error()))
                end,
                $crashed,
                "assert-instance? of error crashes");
@@ -193,17 +231,17 @@ end test testworks-assert-instance?-test;
 
 define test testworks-assert-not-instance?-test ()
   assert-equal(without-recording ()
-                 assert-not-instance?(<string>, 1)
+                 result-status(assert-not-instance?(<string>, 1))
                end,
                $passed,
                "assert-not-instance?(<string>, 1) passes");
   assert-equal(without-recording ()
-                 assert-not-instance?(<integer>, 1)
+                 result-status(assert-not-instance?(<integer>, 1))
                end,
                $failed,
                "assert-not-instance?(<integer>, 1) fails");
   assert-equal(without-recording ()
-                 assert-not-instance?(<integer>, test-error())
+                 result-status(assert-not-instance?(<integer>, test-error()))
                end,
                $crashed,
                "assert-not-instance? of error crashes");
@@ -214,29 +252,29 @@ define test testworks-check-condition-test ()
     let success? = #f;
     assert-equal($passed,
                  without-recording ()
-                   check-condition($internal-check-name,
-                                   <test-error>,
-                                   begin
-                                     // default-handler for <warning> returns #f
-                                     test-warning();
-                                     success? := #t;
-                                     test-error()
-                                   end)
+                   result-status(check-condition($internal-check-name,
+                                                 <test-error>,
+                                                 begin
+                                                   // default-handler for <warning> returns #f
+                                                   test-warning();
+                                                   success? := #t;
+                                                   test-error()
+                                                 end))
                  end,
                  "check-condition catches <test-error>");
     assert-true(success?,
                 "check-condition for <test-error> doesn't catch <warning>");
   end;
   assert-equal(without-recording ()
-                 check-condition($internal-check-name, <test-error>, #f)
+                 result-status(check-condition($internal-check-name, <test-error>, #f))
                end,
                $failed,
                "check-condition fails if no condition");
   assert-equal($failed,
                without-recording ()
-                 check-condition($internal-check-name,
-                                 <test-error>,
-                                 test-warning());
+                 result-status(check-condition($internal-check-name,
+                                               <test-error>,
+                                               test-warning()))
                end,
                "check-condition doesn't catch wrong condition");
 end test testworks-check-condition-test;
@@ -248,48 +286,57 @@ define test testworks-assert-signals-test ()
     let success? = #f;
     assert-equal($passed,
                  without-recording ()
-                  assert-signals(<test-error>,
+                  result-status(assert-signals(<test-error>,
                                  begin
                                    // default-handler for <warning> returns #f
                                    test-warning();
                                    success? := #t;
                                    test-error()
-                                 end)
+                                 end))
                  end);
     assert-true(success?);
   end;
   assert-equal($failed,
                without-recording ()
-                 assert-signals(<test-error>, #f)
+                 result-status(assert-signals(<test-error>, #f))
                end);
   assert-equal($failed,
                without-recording ()
-                 assert-signals(<test-error>, test-warning());
+                 result-status(assert-signals(<test-error>, test-warning()))
                end);
 end test testworks-assert-signals-test;
 
 define test testworks-check-no-errors-test ()
   assert-equal($passed,
                without-recording ()
-                 check-no-errors($internal-check-name, #t)
+                 result-status(check-no-errors($internal-check-name, #t))
                end,
                "check-no-errors of #t passes");
   assert-equal($passed,
                without-recording ()
-                 check-no-errors($internal-check-name, #f)
+                 result-status(check-no-errors($internal-check-name, #f))
                end,
                "check-no-errors of #f passes");
   assert-equal($crashed,
                without-recording ()
-                 check-no-errors($internal-check-name, test-error())
+                 result-status(check-no-errors($internal-check-name, test-error()))
                end,
                "check-no-errors of error crashes");
 end test testworks-check-no-errors-test;
 
 define test testworks-assert-no-errors-test ()
-  assert-equal($passed, without-recording () assert-no-errors(#t) end);
-  assert-equal($passed, without-recording () assert-no-errors(#f) end);
-  assert-equal($crashed, without-recording () assert-no-errors(test-error()) end);
+  assert-equal($passed,
+               without-recording ()
+                 result-status(assert-no-errors(#t))
+               end);
+  assert-equal($passed,
+               without-recording ()
+                 result-status(assert-no-errors(#f))
+               end);
+  assert-equal($crashed,
+               without-recording ()
+                 result-status(assert-no-errors(test-error()))
+               end);
 end test testworks-assert-no-errors-test;
 
 define suite testworks-assertion-macros-suite ()


### PR DESCRIPTION
Some minor clean up. Hopefully this helps us move in the direction of sharing more code between the `do-check-*` functions and subsequently being able to export the helper function to let libraries write their own assertions.

This would be useful for the `dfmc-testing` tests for the `dfmc-typist` as this would let it provide more useful feedback when a `typist-inference` test fails.