### PR TITLE
run-test-application: run all defined tests if called with no arguments

### DIFF
--- a/components.dylan
+++ b/components.dylan
@@ -161,6 +161,18 @@ end macro suite-definer;
 
 /// Tests
 
+// All tests and benchmarks are registered here.
+define constant $tests = make(<stretchy-vector>);
+
+define function register-test (test :: <runnable>)
+  if (member?(test, $tests, test: method (t1, t2)
+                                    component-name(t1) = component-name(t2)
+                                  end))
+    error("Duplicate test name: %=", component-name(test));
+  end;
+  add!($tests, test);
+end;
+
 define macro test-definer
   { define test ?test-name:name (?keyword-args:*) ?test-body:body end
   } => {
@@ -169,6 +181,7 @@ define macro test-definer
                                       name: ?"test-name",
                                       function: "%%" ## ?test-name,
                                       ?keyword-args);
+    register-test(?test-name);
   }
 end macro test-definer;
 
@@ -181,6 +194,7 @@ define macro benchmark-definer
              name: ?"test-name",
              function: "%%" ## ?test-name,
              ?keyword-args);
+    register-test(?test-name);
   }
 end macro benchmark-definer;
 

--- a/documentation/users-guide/source/reference.rst
+++ b/documentation/users-guide/source/reference.rst
@@ -22,26 +22,6 @@ The Testworks Module
 Suites, Tests, and Benchmarks
 -----------------------------
 
-.. macro:: suite-definer
-
-   Define a new test suite.
-
-   :signature: define suite *suite-name* (#key *setup-function cleanup-function description*) *body* end
-   :parameter suite-name: Name of the suite; a Dylan variable name.
-   :parameter #key setup-function: A function to perform setup before the suite starts.
-   :parameter #key cleanup-function: A function to perform teardown after the suite finishes.
-   :parameter #key description: A string describing the purpose of the suite.
-
-   Suites provide a way to group tests and other suites into a single
-   executable unit.  Suites may be nested arbitrarily.
-
-   *setup-function* is executed before any tests or sub-suites are
-   run.  If *setup-function* signals an error the entire suite is
-   skipped and marked as "crashed".
-
-   *cleanup-function* is executed after all sub-suites and tests have
-   completed, regardless of whether an error is signaled.
-
 .. macro:: test-definer
 
    Define a new test.
@@ -83,20 +63,30 @@ Suites, Tests, and Benchmarks
       fail.
    :parameter #key tags: A list of strings to tag this benchmark.
 
-   Benchmarks may contain arbitrary code and may use assertions,
-   although that isn't required.  If the benchmark signals an error it
-   is marked as "crashed".
+   Benchmarks may contain arbitrary code and do not require any
+   assertions.  If the benchmark signals an error it is marked as
+   "crashed". Other than this, and some differences in how the results
+   are displayed, benchmarks are the same as tests.
 
-   If *expected-failure?* is set to ``#t`` or a function that when executed
-   returns a true value, then the test will be expected to fail. Such a failure
-   will be treated as a successful test run. If the test passes rather than
-   failing, then that will be considered a test failure. This option has
-   no effect on tests which are *not implemented* or which have *crashed*.
+.. macro:: suite-definer
 
-   *tags* provide a way to select or filter out specific tests during
-   a test run.  The Testworks command-line (provided by
-   :func:`run-test-application`) provides a ``--tag`` option for this
-   purpose.
+   Define a new test suite.
+
+   :signature: define suite *suite-name* (#key *setup-function cleanup-function description*) *body* end
+   :parameter suite-name: Name of the suite; a Dylan variable name.
+   :parameter #key setup-function: A function to perform setup before the suite starts.
+   :parameter #key cleanup-function: A function to perform teardown after the suite finishes.
+   :parameter #key description: A string describing the purpose of the suite.
+
+   Suites provide a way to group tests and other suites into a single
+   executable unit.  Suites may be nested arbitrarily.
+
+   *setup-function* is executed before any tests or sub-suites are
+   run.  If *setup-function* signals an error the entire suite is
+   skipped and marked as "crashed".
+
+   *cleanup-function* is executed after all sub-suites and tests have
+   completed, regardless of whether an error is signaled.
 
 Assertions
 ----------
@@ -473,8 +463,10 @@ Test Execution
 
    Run a test suite or test as part of a stand-alone test executable.
 
-   :signature: run-test-application *suite-or-test* => ()
-   :parameter suite-or-test: An instance of :class:`<suite>` or :class:`<runnable>`.
+   :signature: run-test-application #rest *suite-or-test* => ()
+   :parameter suite-or-test: (optional) An instance of
+      :class:`<suite>` or :class:`<runnable>`. If not supplied
+      then all tests and benchmarks are run.
 
    This is the main entry point to run a set of tests in Testworks.
    It parses the command-line and based on the specified options
@@ -483,7 +475,7 @@ Test Execution
 
    Internally, :func:`run-test-application` creates a
    :class:`<test-runner>` based on the command-line options and then
-   calls :func:`run-tests` with the runner and *suite-or-test*.
+   calls :func:`run` with the runner and *suite-or-test*.
 
 .. function:: test-option
 

--- a/gui/progress-window.dylan
+++ b/gui/progress-window.dylan
@@ -202,7 +202,7 @@ end method handle-event;
 /// Simple wrapper function
 
 // TODO(cgay): In the testworks library I replaced perform-{suite,test,component}
-// with run-tests.  It should be done here too but I'm making minimal changes in
+// with run.  It should be done here too but I'm making minimal changes in
 // testworks-gui right now since it's difficult to test it.
 
 define function gui-perform-suite

--- a/library.dylan
+++ b/library.dylan
@@ -12,7 +12,7 @@ define library testworks
   use io, import: { format, print, standard-io, streams };
   use coloring-stream;
   use strings;
-  use system, import: { file-system };
+  use system, import: { file-system, locators };
 
   export
     testworks,
@@ -77,14 +77,15 @@ end module testworks;
 
 // Internals, for use by test suite.
 define module %testworks
+  use coloring-stream;
   use command-line-parser;
   use common-dylan, exclude: { format-to-string };
   use file-system;
   use format;
+  use locators, import: { <file-locator>, locator-base };
   use print, import: { print-object };
   use standard-io;
   use streams;
-  use coloring-stream;
   use strings, import: { char-compare-ic, starts-with?, string-equal? };
   use testworks;
   use threads,

--- a/tests/specification.dylan
+++ b/tests/specification.dylan
@@ -43,7 +43,7 @@ define module-spec %testworks ()
   class <component-result> (<result>);
   constant $not-implemented :: <object>;
   function debug-failures? () => (<boolean>);
-  function make-runner-from-command-line (<component>, <command-line-parser>) => (<component>, <test-runner>, <function>);
+  function make-runner-from-command-line (false-or(<component>), <command-line-parser>) => (<component>, <test-runner>, <function>);
   function result-name (<object>) => (<string>);
   function tags-match? (<sequence>, <component>) => (<boolean>);
   constant $passed :: <object>;
@@ -84,12 +84,12 @@ define module-spec testworks ()
   macro-test check-no-condition-test;
   macro-test assert-equal-test;
   macro-test check-no-errors-test;
-  function run-test-application (<component>) => (false-or(<result>));
+  function run-test-application (false-or(<component>)) => (false-or(<result>));
   macro-test assert-not-equal-test;
   // generated without "instantiable"
   open instantiable class <test-runner> (<object>);
   open generic-function check-equal-failure-detail (<object>, <object>) => (false-or(<string>));
-  function run-tests (<test-runner>, <component>) => (<component-result>);
+  function run-tests (<test-runner>, <component>) => (false-or(<component-result>));
   macro-test assert-false-test;
   macro-test assert-signals-test;
   macro-test check-condition-test;
@@ -407,6 +407,10 @@ end class-test <test-runner>;
 define testworks function-test check-equal-failure-detail ()
   //---*** Fill this in...
 end function-test check-equal-failure-detail;
+
+define testworks function-test run ()
+  //---*** Fill this in...
+end function-test run;
 
 define testworks function-test run-tests ()
   //---*** Fill this in...

--- a/tests/testworks-test-suite-app.dylan
+++ b/tests/testworks-test-suite-app.dylan
@@ -6,4 +6,4 @@ Copyright:    Original Code is Copyright (c) 1995-2004 Functional Objects, Inc.
 License:      See License.txt in this distribution for details.
 Warranty:     Distributed WITHOUT WARRANTY OF ANY KIND
 
-run-test-application(testworks-test-suite);
+run-test-application();

--- a/tests/testworks-test-suite.dylan
+++ b/tests/testworks-test-suite.dylan
@@ -411,17 +411,26 @@ define test test-with-test-unit ()
   end;
 end test test-with-test-unit;
 
-define test test-expected-failure-always(expected-failure?: #t)
-  assert-true(#f);
-end test;
+// The following tests are defined without using "define test" so that
+// they don't get registered and then run as normal tests (which would fail).
 
-define test test-expected-failure-maybe(expected-failure?: method () #t end)
-  assert-true(#f);
-end test;
+define constant test-expected-failure-always
+  = make(<test>,
+         name: "test-expected-failure-always",
+         function: method () assert-true(#f) end,
+         expected-failure?: #t);
 
-define test test-unexpected-success(expected-failure?: #t)
-  assert-true(#t);
-end test;
+define constant test-expected-failure-maybe
+  = make(<test>,
+         name: "test-expected-failure-maybe",
+         function: method () assert-true(#f) end,
+         expected-failure?: method () #t end);
+
+define constant test-unexpected-success
+  = make(<test>,
+         name: "test-unexpected-success",
+         function: method () assert-true(#t) end,
+         expected-failure?: #t);
 
 define suite expected-failure-suite ()
   test test-expected-failure-always;


### PR DESCRIPTION
...when called with zero args.  It may still be called with a suite as its only arg for backward compatibility, but this enables the simple case of
```
define test foo () ... end;
define test bar () ... end;
run-test-application();
```
Done.