### PR TITLE
A few minor enhancements and bug fixes

### DIFF
--- a/documentation/users-guide/source/reference.rst
+++ b/documentation/users-guide/source/reference.rst
@@ -26,9 +26,8 @@ Suites, Tests, and Benchmarks
 
    Define a new test.
 
-   :signature: define test *test-name* (#key *description, expected-failure?, tags*) *body* end
+   :signature: define test *test-name* (#key *expected-failure?, tags*) *body* end
    :parameter test-name: Name of the test; a Dylan variable name.
-   :parameter #key description: A string describing the purpose of the test.
    :parameter #key expected-failure?: An instance of either :drm:`<boolean>` or
       :drm:`<function>`. This indicates whether or not the test is expected to
       fail.
@@ -55,9 +54,8 @@ Suites, Tests, and Benchmarks
 
    Define a new benchmark.
 
-   :signature: define benchmark *name* (#key *description, expected-failure?, tags*) *body* end
+   :signature: define benchmark *name* (#key *expected-failure?, tags*) *body* end
    :parameter name: Name of the benchmark; a Dylan variable name.
-   :parameter #key description: A string describing the purpose of the benchmark.
    :parameter #key expected-failure?: An instance of either :drm:`<boolean>` or
       :drm:`<function>`. This indicates whether or not the test is expected to
       fail.
@@ -72,11 +70,10 @@ Suites, Tests, and Benchmarks
 
    Define a new test suite.
 
-   :signature: define suite *suite-name* (#key *setup-function cleanup-function description*) *body* end
+   :signature: define suite *suite-name* (#key *setup-function cleanup-function*) *body* end
    :parameter suite-name: Name of the suite; a Dylan variable name.
    :parameter #key setup-function: A function to perform setup before the suite starts.
    :parameter #key cleanup-function: A function to perform teardown after the suite finishes.
-   :parameter #key description: A string describing the purpose of the suite.
 
    Suites provide a way to group tests and other suites into a single
    executable unit.  Suites may be nested arbitrarily.

--- a/library.dylan
+++ b/library.dylan
@@ -34,11 +34,12 @@ define module testworks
     run-tests,
     *runner*,
     <test-runner>,
-    runner-tags,
-    runner-skip,
+    debug-runner?,
+    runner-options,
     runner-output-stream,
     runner-progress,
-    debug-runner?;
+    runner-skip,
+    runner-tags;
 
   // Checks (deprecated, use assertions)
   create

--- a/run.dylan
+++ b/run.dylan
@@ -51,6 +51,9 @@ define open class <test-runner> (<object>)
       = colorize-stream(*standard-output*),
     init-keyword: output-stream:;
 
+  // Options are from positional args passed as key=val on the
+  // command-line and can be used to pass external context information
+  // to tests. For example, test data directory pathname.
   constant slot runner-options :: <string-table> = make(<string-table>),
     init-keyword: options:;
 end class <test-runner>;
@@ -341,8 +344,6 @@ define method show-progress
     test-output("\n  %s: [%s]\n  ", result.result-name, reason);
   end;
 end method show-progress;
-
-/// Test options
 
 define function test-option
     (name :: <string>, #key default = unsupplied())

--- a/run.dylan
+++ b/run.dylan
@@ -119,6 +119,8 @@ define method maybe-execute-component
              microseconds: 0,
              bytes: 0)
       end;
+  force-output(*standard-error*);
+  force-output(*standard-output*);
   if (runner.runner-progress)
     show-progress(runner, component, result);
   end;

--- a/tests/test-command-line.dylan
+++ b/tests/test-command-line.dylan
@@ -9,7 +9,6 @@ define test test-make-runner-from-command-line ()
                   list("--debug=failures", debug-runner?, #t));
   let dummy-component = make(<suite>,
                              name: "Dummy",
-                             description: "not used",
                              components: #());
   for (item in args)
     let (arg, getter, expected) = apply(values, item);

--- a/tests/testworks-test-suite-library.dylan
+++ b/tests/testworks-test-suite-library.dylan
@@ -7,9 +7,12 @@ License:      See License.txt in this distribution for details.
 Warranty:     Distributed WITHOUT WARRANTY OF ANY KIND
 
 define library testworks-test-suite
+  use collections,
+    import: { table-extensions };
   use command-line-parser;
   use common-dylan;
-  use io, import: { format };
+  use io,
+    import: { format };
   use strings;
   use testworks;
   use testworks-specs;
@@ -22,6 +25,8 @@ define module testworks-test-suite
   use common-dylan;
   use format;
   use strings;
+  use table-extensions,
+    import: { table => tabling };
   use testworks;
   use testworks-specs;
   use %testworks;


### PR DESCRIPTION
Most of the original removal was done in 281d721.
Fixes #88.

There are probably a lot of callers of "define test" etc in OD that use this obsolete keyword...