### PR TITLE
Remove use of uncommon-dylan, which is not an opendylan submodule.

### DIFF
--- a/components.dylan
+++ b/components.dylan
@@ -209,7 +209,7 @@ define function find-root-components () => (components :: <sequence>)
   for (c in $components)
     if (instance?(c, <suite>))
       for (sub in suite-components(c))
-        inc!(refs[sub]);
+        refs[sub] := refs[sub] + 1;
       end;
     end;
   end;

--- a/library.dylan
+++ b/library.dylan
@@ -16,8 +16,6 @@ define library testworks
   use strings;
   use system,
     import: { file-system, locators };
-  use uncommon-dylan,
-    import: { uncommon-utils };
 
   export
     testworks,
@@ -96,8 +94,6 @@ define module %testworks
   use testworks;
   use threads,
     import: { dynamic-bind };
-  use uncommon-utils,
-    import: { inc! };
 
   // Debugging options
   export


### PR DESCRIPTION
It was only used for the inc! macro, which isn't very important.  I'm
not sure, but I may have started out using uncommon-dylan more than
that and then pared it down to just inc! without thinking to remove
it.