### PR TITLE
Implement a standalone testworks-run app

### DIFF
--- a/registry/generic/testworks-run
+++ b/registry/generic/testworks-run
@@ -1,0 +1,1 @@
+abstract://dylan/run/testworks-run.lid

--- a/run/library.dylan
+++ b/run/library.dylan
@@ -1,0 +1,22 @@
+Module:    dylan-user
+Synopsis:  Runner for executing Testworks libraries
+Copyright:    Original Code is Copyright (c) 1995-2004 Functional Objects, Inc.
+              All rights reserved.
+License:      See License.txt in this distribution for details.
+Warranty:     Distributed WITHOUT WARRANTY OF ANY KIND
+
+define library testworks-run
+  use common-dylan;
+  use system;
+  use io;
+  use testworks;
+end library testworks-run;
+
+define module testworks-run
+  use common-dylan;
+  use format;
+  use streams;
+  use standard-io;
+  use operating-system;
+  use testworks;
+end module testworks-run;

--- a/run/testworks-run.dylan
+++ b/run/testworks-run.dylan
@@ -1,0 +1,8 @@
+Module: testworks-run
+Synopsis: Runner for executing Testworks libraries
+Copyright:    Original Code is Copyright (c) 1995-2004 Functional Objects, Inc.
+              All rights reserved.
+License:      See License.txt in this distribution for details.
+Warranty:     Distributed WITHOUT WARRANTY OF ANY KIND
+
+run-test-application();

--- a/run/testworks-run.lid
+++ b/run/testworks-run.lid
@@ -1,0 +1,10 @@
+Library: testworks-run
+Target-Type: executable
+files: library
+       testworks-run
+Compilation-Mode: tight
+Target-Type: executable
+Copyright:    Original Code is Copyright (c) 1995-2004 Functional Objects, Inc.
+              All rights reserved.
+License:      See License.txt in this distribution for details.
+Warranty:     Distributed WITHOUT WARRANTY OF ANY KIND


### PR DESCRIPTION
So that it is no longer necessary to build a test-runner application for each test suite library, these changes add a --load option to the testworks run-test-application function, and provide a standalone application that can be used to load test suite libraries and run them.
