### PR TITLE
Add a benchmark-repeat macro and benchmark analysis

### DIFF
--- a/benchmark.dylan
+++ b/benchmark.dylan
@@ -33,7 +33,61 @@ end;
 define class <benchmark-result> (<component-result>)
 end;
 
+define class <benchmark-iteration-result> (<unit-result>, <metered-result>)
+end;
+
 define method result-type-name
     (result :: <benchmark-result>) => (name :: <string>)
   "Benchmark"
 end;
+
+define method result-type-name
+    (result :: <benchmark-iteration-result>) => (name :: <string>)
+  "Iteration"
+end;
+
+define thread variable *benchmark-recording-function* = always(#f);
+
+define macro benchmark-repeat
+  { benchmark-repeat (#key ?iterations:expression = 1)
+      ?:body
+    end }
+    => { local
+           method benchmark-body ()
+             ?body
+           end;
+         let name = full-component-name(*component*);
+         for (iteration :: <integer> from 0 below ?iterations,
+              iteration-values = #[]
+                then begin
+                       collect-garbage();
+                       profiling (cpu-time-seconds,
+                                  cpu-time-microseconds,
+                                  allocation)
+                         let (#rest iteration-values) = benchmark-body();
+                         iteration-values
+                       results
+                         record-benchmark-iteration(name,
+                                                    cpu-time-seconds,
+                                                    cpu-time-microseconds,
+                                                    allocation);
+                       end profiling
+                     end)
+         finally
+           apply(values, iteration-values)
+         end for }
+end;
+
+define method record-benchmark-iteration
+    (name, cpu-time-seconds :: <integer>, cpu-time-microseconds :: <integer>,
+     allocation :: <integer>)
+ => (status :: <result>)
+  let result = make(<benchmark-iteration-result>,
+                    name: name,
+                    status: $passed,
+                    seconds: cpu-time-seconds,
+                    microseconds: cpu-time-microseconds,
+                    bytes: allocation);
+  *benchmark-recording-function*(result);
+  result
+end method record-benchmark-iteration;

--- a/command-line.dylan
+++ b/command-line.dylan
@@ -19,6 +19,7 @@ define table $report-functions :: <string-table> = {
     "none"     => null-report-function,
     "summary"  => summary-report-function,
     "failures" => failures-report-function,
+    "full"     => full-report-function,
     "surefire" => surefire-report-function,
     "xml"      => xml-report-function
 };

--- a/library.dylan
+++ b/library.dylan
@@ -16,6 +16,7 @@ define library testworks
   use strings;
   use system,
     import: { date, file-system, locators, operating-system };
+  use memory-manager;
 
   export
     testworks,
@@ -69,6 +70,10 @@ define module testworks
     benchmark-definer,
     with-test-unit;
 
+  // Benchmarks
+  create
+    benchmark-repeat;
+
   // Output
   create
     test-output,
@@ -105,6 +110,7 @@ define module %testworks
   use testworks;
   use threads,
     import: { dynamic-bind };
+  use memory-manager, import: { collect-garbage };
 
   // Debugging options
   export

--- a/reports.dylan
+++ b/reports.dylan
@@ -136,7 +136,7 @@ define method print-result-info
     format(stream, "\n%s%s %s",
            indent, result.result-name, status-name(result-status));
     if (result-status == $passed
-        & instance?(result, <component-result>))
+        & instance?(result, <metered-result>))
       format(stream, " in %s seconds with %s bytes allocated.",
              result-time(result), result-bytes(result) | "?");
     end if
@@ -337,7 +337,7 @@ define method do-xml-result-body
 end method do-xml-result-body;
 
 define method do-xml-result-body
-    (result :: <component-result>, stream :: <stream>) => ()
+    (result :: <metered-result>, stream :: <stream>) => ()
   next-method();
   do-xml-element("seconds",
                  method ()
@@ -354,6 +354,11 @@ define method do-xml-result-body
                    format(stream, "%d", result.result-bytes)
                  end,
                  stream);
+end method do-xml-result-body;
+
+define method do-xml-result-body
+    (result :: <component-result>, stream :: <stream>) => ()
+  next-method();
   if (result.result-reason)
     do-xml-element("reason",
                    method ()

--- a/results.dylan
+++ b/results.dylan
@@ -48,12 +48,7 @@ define class <result> (<object>)
     required-init-keyword: reason:;
 end class <result>;
 
-define class <component-result> (<result>)
-  constant slot result-subresults :: <sequence> = make(<stretchy-vector>),
-    init-keyword: subresults:;
-
-  // Profiling data...
-
+define class <metered-result> (<result>)
   constant slot result-seconds :: false-or(<integer>),
     required-init-keyword: seconds:;
   constant slot result-microseconds :: false-or(<integer>),
@@ -61,6 +56,11 @@ define class <component-result> (<result>)
   // Hopefully nothing will allocate more than 536MB haha...
   constant slot result-bytes :: false-or(<integer>),
     required-init-keyword: bytes:;
+end class <metered-result>;
+
+define class <component-result> (<metered-result>)
+  constant slot result-subresults :: <sequence> = make(<stretchy-vector>),
+    init-keyword: subresults:;
 end class <component-result>;
 
 define class <test-result> (<component-result>)
@@ -114,7 +114,7 @@ end;
 
 
 define method result-time
-    (result :: <component-result>, #key pad-seconds-to :: false-or(<integer>))
+    (result :: <metered-result>, #key pad-seconds-to :: false-or(<integer>))
  => (seconds :: <string>)
   time-to-string(result.result-seconds, result.result-microseconds,
                  pad-seconds-to: pad-seconds-to)

--- a/results.dylan
+++ b/results.dylan
@@ -133,3 +133,10 @@ define function time-to-string
   end
 end function time-to-string;
 
+define function float-time-to-string
+    (time :: <double-float>, #key pad-seconds-to :: false-or(<integer>))
+ => (seconds :: <string>)
+  let seconds = truncate(time);
+  time-to-string(seconds, truncate((time - seconds) * 1.0d6),
+                 pad-seconds-to: pad-seconds-to)
+end;

--- a/run.dylan
+++ b/run.dylan
@@ -220,6 +220,11 @@ define method execute-component
                           show-progress(*runner*, #f, result);
                         end;
                         result
+                      end,
+                    *benchmark-recording-function* =
+                      method (result :: <result>)
+                        add!(subresults, result);
+                        result
                       end)
         let cond
           = profiling (cpu-time-seconds, cpu-time-microseconds, allocation)


### PR DESCRIPTION
This pull request adds support for repeatedly executing code to be benchmarks for a specified number of iterations, and performing basic statistical analysis on the per-iteration results.
