### PR TITLE
Reduce verbosity/redundancy in assert-equal failures

### DIFF
--- a/assertions.dylan
+++ b/assertions.dylan
@@ -104,9 +104,8 @@ define function do-check-equal
                          check-equal-failure-detail(val1, val2)
                        end;
           values($failed,
-                 format-to-string("%= (from expression %=) and %= (from "
-                                    "expression %=) are %s=.%s%s",
-                                  val1, expr1, val2, expr2,
+                 format-to-string("%= and %= are %s=.%s%s",
+                                  val1, val2,
                                   if (negate?) "" else "not " end,
                                   if (detail) "  " else "" end,
                                   detail | ""))


### PR DESCRIPTION
Adding "(from expression ...)" is redundant with the auto-generated test name.

Changed from this:
```
   "{1:2}" = to-string(table, #f) failed ["{1:2}" (from expression "\"{1:2}\"") and "{1: 2}" (from expression "to-string(table, #f)") are not =.  sizes differ (5 and 6), element 3 is the first non-matching element]
```
to this:
```
   "{1:2}" = to-string(table, #f): ["{1:2}" and "{1: 2}" are not =.  sizes differ (5 and 6), element 3 is the first non-matching element]
```