### PR TITLE
Update spec to match result-time function

### DIFF
--- a/library.dylan
+++ b/library.dylan
@@ -163,6 +163,7 @@ define module %testworks
     <component-result>,
     result-subresults,
 
+    <metered-result>,
     <test-result>,
     <benchmark-result>,
     <suite-result>,

--- a/tests/specification.dylan
+++ b/tests/specification.dylan
@@ -16,7 +16,7 @@ define module-spec %testworks ()
   function result-microseconds (<object>) => (false-or(<integer>));
   class <test-result> (<component-result>);
   open generic-function execute-component? (<component>, <test-runner>) => (<boolean>);
-  function result-time (<component-result>, #"key", #"pad-seconds-to") => (<string>);
+  function result-time (<metered-result>, #"key", #"pad-seconds-to") => (<string>);
   function parse-tags (<sequence>) => (<sequence>);
   function summary-report-function (<result>, <stream>) => ();
   function debug? () => (<boolean>);


### PR DESCRIPTION
Export <metered-result> from %testworks, for the test suite.

Fixes one test failure.