### PR TITLE
[testworks] Downcase result-type-name values

### DIFF
--- a/benchmark.dylan
+++ b/benchmark.dylan
@@ -38,12 +38,12 @@ end;
 
 define method result-type-name
     (result :: <benchmark-result>) => (name :: <string>)
-  "Benchmark"
+  "benchmark"
 end;
 
 define method result-type-name
     (result :: <benchmark-iteration-result>) => (name :: <string>)
-  "Iteration"
+  "iteration"
 end;
 
 define thread variable *benchmark-recording-function* = always(#f);


### PR DESCRIPTION
To match an earlier commit that changed the other methods on this function.

testworks-test-suite-app passes