### PR TITLE
[testworks reports] fix write/read of crashed tests

### DIFF
--- a/report/readers.dylan
+++ b/report/readers.dylan
@@ -17,7 +17,7 @@ define method parse-status
   select (status-string by \=)
     "passed" => $passed;
     "failed" => $failed;
-    "crashed" => recreate-error(reason);
+    "crashed" => $crashed;
     "skipped" => $skipped;
     "failed as expected" => $expected-failure;
     "unexpectedly succeeded" => $unexpected-success;
@@ -333,14 +333,3 @@ define method find
     end;
   end
 end method find;
-
-
-define class <recreated-error> (<error>)
-end class <recreated-error>;
-
-define method recreate-error
-    (string :: <string>) => (error :: <recreated-error>)
-  make(<recreated-error>,
-       format-string: "%s",
-       format-arguments: vector(string))
-end method recreate-error;

--- a/reports.dylan
+++ b/reports.dylan
@@ -538,7 +538,7 @@ define method result-to-table (result :: <result>) => (t :: <table>)
   let t = make(<string-table>, size: 8);
   t["type"] := result-type-name(result);
   t["name"] := result.result-name;
-  t["status"] := result.result-status;
+  t["status"] := status-name(result.result-status);
   t["reason"] := result.result-reason;
   t
 end;


### PR DESCRIPTION
With this the json reports for dylan-test-suite can be read by testworks-report.