### PR TITLE
Remove the "log" report format

### DIFF
--- a/command-line.dylan
+++ b/command-line.dylan
@@ -20,7 +20,6 @@ define constant $verbose = #"verbose";
 // --verbose (or --output) should apply to the former.
 define table $report-functions :: <string-table>
   = {
-     "log"      => log-report-function, // Why are these named "-function"?
      "none"     => null-report-function,
      "summary"  => summary-report-function,
      "failures" => failures-report-function,

--- a/library.dylan
+++ b/library.dylan
@@ -199,7 +199,6 @@ define module %testworks
     summary-report-function,
     failures-report-function,
     full-report-function,
-    log-report-function,
     xml-report-function,
     surefire-report-function;
 
@@ -209,8 +208,6 @@ define module %testworks
     parse-args;
 
   export
-    $test-log-header,
-    $test-log-footer,
     $xml-version-header,
     *check-recording-function*;
 

--- a/report/initialize.dylan
+++ b/report/initialize.dylan
@@ -8,7 +8,7 @@ Warranty:     Distributed WITHOUT WARRANTY OF ANY KIND
 
 /// Application options
 
-// TODO(cgay): use command-line-parser library
+// TODO(cgay): use command-line-parser https://github.com/dylan-lang/testworks/issues/121
 
 define class <application-options> (<object>)
   constant slot application-quiet? :: <boolean> = #f,
@@ -82,6 +82,7 @@ end method display-run-options;
 
 /// application-error
 
+// TODO(cgay): this should be defined in the testworks module
 define class <testworks-error> (<format-string-condition>, <error>)
 end;
 
@@ -147,8 +148,8 @@ end method argument-value;
 define constant $help-format-string =
   "Application: %s\n"
   "\n"
-  "  Arguments: log1\n"
-  "             [log2]\n"
+  "  Arguments: report1\n"
+  "             [report2]\n"
   "             [-quiet]\n"
   "             [-report [full failures summary diff full-diff diff-summary benchmark-diff]]\n"
   "             [-suite <name1> <name2> ... ...]\n"
@@ -228,7 +229,7 @@ define method parse-arguments
     end
   end;
   unless (log1)
-    invalid-argument("Log file missing - one or two log files must be supplied\n")
+    invalid-argument("Report file missing - one or two report files must be supplied\n")
   end;
   unless (report-function)
     report-function := if (log2)
@@ -241,14 +242,14 @@ define method parse-arguments
                                              failures-report-function,
                                              summary-report-function)))
     invalid-argument("The report function specified is not meaningful "
-                     "when two log files are specified.\n");
+                     "when two report files are specified.\n");
   end if;
   if (~log2 & member?(report-function, vector(diff-report-function,
                                               diff-full-report-function,
                                               diff-summary-report-function,
                                               benchmark-diff-report-function)))
     invalid-argument("The report function specified is only meaningful "
-                     "when two log files are specified.\n");
+                     "when two report files are specified.\n");
   end if;
   make(<application-options>,
        log1: log1, log2: log2,

--- a/report/readers.dylan
+++ b/report/readers.dylan
@@ -6,10 +6,6 @@ Copyright:    Original Code is Copyright (c) 1995-2004 Functional Objects, Inc.
 License:      See License.txt in this distribution for details.
 Warranty:     Distributed WITHOUT WARRANTY OF ANY KIND
 
-define constant $testworks-message
-  = "Make sure the test report was generated using the \"-report log\"\n"
-    "or \"-report xml\" option to testworks.";
-
 // It looks like this and testworks:status-name are meant to be
 // inverses.  (This would be a good use for an <enum> class.)
 define method parse-status
@@ -23,181 +19,24 @@ define method parse-status
     "unexpectedly succeeded" => $unexpected-success;
     "not implemented" => $not-implemented;
     otherwise =>
-      error("Unexpected status '%s' in report", status-string);
+      application-error("Unexpected status '%s' in report", status-string);
   end
 end method parse-status;
-
-define method make-result
-    (type, name, status, reason, subresults, ignored-tests, ignored-suites,
-     seconds, microseconds, allocation)
-  let status = parse-status(status, reason);
-  select (as(<symbol>, type))
-    #"check" =>
-      make(<check-result>,
-           name: name, status: status, reason: reason);
-    #"test-unit" =>
-      unless (member?(as-lowercase(name), ignored-tests, test: \=))
-        make(<test-unit-result>,
-             name: name, status: status, reason: reason);
-      end;
-    #"benchmark" =>
-      make(<benchmark-result>,
-           name: name, status: status, reason: reason,
-           seconds: seconds, microseconds: microseconds,
-           bytes: allocation);
-    #"test" =>
-      unless (member?(as-lowercase(name), ignored-tests, test: \=))
-        make(<test-result>,
-             name: name, status: status, subresults: subresults)
-      end;
-    #"suite" =>
-      if (~member?(as-lowercase(name), ignored-suites, test: \=))
-        debug-message("Read %s", name);
-        make(<suite-result>,
-             name: name, status: status, subresults: subresults)
-      else
-        debug-message("Ignored %s", name)
-      end;
-    otherwise =>
-      error("Unexpected component type '%s'", type);
-  end
-end method make-result;
-
-// TODO(cgay): this is completely broken. Not sure when it happened.
-// Maybe we can just remove the "log" format and use json or xml instead?
-define function read-log-report-1
-    (stream :: <stream>, #key ignored-tests = #[], ignored-suites = #[])
- => (result :: <result>)
-  block (return)
-    let last-line = #f;
-    // Read next non-blank line.  Error if EOF reached, since that means
-    // the log file wasn't written correctly anyway.
-    local method read-next-line (#key error?) => (line :: <string>)
-            let next-line = last-line;
-            if (next-line)
-              last-line := #f;
-              next-line
-            else
-              let line = read-line(stream);
-              while (line = "")
-                line := read-line(stream);
-              end;
-              line
-            end if
-          end method read-next-line;
-    local method unread-line (line :: <string>) => ()
-            last-line := line;
-          end;
-    local method line-starts-with (line :: <string>, s :: <string>) => (b :: <boolean>)
-            block (return)
-              let len = size(line);
-              for (i from 0 below size(s))
-                if (i >= len | line[i] ~= s[i])
-                  return(#f);
-                end if;
-              end for;
-              #t
-            end block
-          end method line-starts-with;
-    local method maybe-read-keyword-line
-              (keyword :: <string>) => (value :: false-or(<string>))
-            let line = read-next-line();
-            if (line-starts-with(line, keyword))
-              as(<string>, copy-sequence(line, start: keyword.size))
-            else
-              unread-line(line);
-              #f
-            end
-          end method maybe-read-keyword-line;
-    local method read-keyword-line (keyword :: <string>) => (value :: <string>)
-            maybe-read-keyword-line(keyword)
-              | application-error("Error parsing report: The keyword \"%s\" was not found.\n%s\n",
-                                  keyword, $testworks-message);
-          end method read-keyword-line;
-    local method read-end-token () => ()
-            unless (line-starts-with(read-next-line(), "end"))
-              application-error("Error parsing report: 'end' token not found.\n%s\n",
-                                $testworks-message);
-            end;
-          end method read-end-token;
-    local method read-log-file-section () => (result :: false-or(<result>))
-            let type          = read-keyword-line("Object: ");
-            let name          = read-keyword-line("Name: ");
-            let status        = read-keyword-line("Status: ");
-            let reason        = maybe-read-keyword-line("Reason: ");
-            let seconds       = #f;
-            let microseconds  = #f;
-            let allocation    = #f;
-            let subresults
-              = if (type = "Check")
-                  read-end-token();
-                elseif (type = "Benchmark")
-                  // If there is no "Reason:" line for a benchmark then there
-                  // are "Seconds:" and "Allocation:".
-                  if (~reason)
-                    let time = read-keyword-line("Seconds: ");
-                    let alloc = read-keyword-line("Allocation: ");
-                    let (secs, index) = string-to-integer(time);
-                    seconds := secs;
-                    microseconds := string-to-integer(time, start: index + 1);
-                    allocation := string-to-integer(alloc);
-                  end if;
-                  read-end-token();
-                else  // type is "Test" or "Suite" or "Test unit"
-                  let subresults = make(<stretchy-vector>);
-                  let line = read-next-line();
-                  until (line-starts-with(line, "end"))
-                    unread-line(line);
-                    let subresult = read-log-file-section();
-                    subresult & add!(subresults, subresult);
-                    line := read-next-line();
-                  end;
-                  subresults
-                end;
-            make-result(type, name, status, reason, subresults,
-                        ignored-tests, ignored-suites,
-                        seconds, microseconds, allocation)
-          end;
-    block ()
-      read-log-file-section();
-    exception (e :: <end-of-stream-error>)
-      application-error("Error parsing report: End of file reached.\n%s\n",
-                        $testworks-message);
-    end block
-  end block
-end function;
-
-define function read-log-report
-    (stream :: <stream>, path :: <string>, #key ignored-tests = #[], ignored-suites = #[])
- => (result :: <result>)
-  // Skip past the report header line.
-  block (exit-block)
-    while (#t)
-      let line = read-line(stream, on-end-of-stream: #f)
-        | application-error("%s doesn't appear to be a Testworks log report.\n%s\n",
-                            path, $testworks-message);
-      if (line = $test-log-header)
-        exit-block();
-      end;
-    end;
-  end block;
-  read-log-report-1(stream, ignored-tests: ignored-tests, ignored-suites: ignored-suites)
-    | application-error("There are no matching results in log file %s\n%s\n",
-                        path, $testworks-message)
-end function;
 
 define function read-report
     (path :: <string>, #key ignored-tests = #[], ignored-suites = #[])
  => (result :: <result>)
-  let reader = select (locator-extension(as(<file-locator>, path)) by \=)
-                 "xml" => read-xml-report;
-                 "json" => read-json-report;
-                 otherwise => read-log-report; // .log and...who knows what else!
-               end;
+  let extension = locator-extension(as(<file-locator>, path));
+  let reader
+    = select (extension by string-equal-ic?)
+        // TODO(cgay): read surefire xml format
+        "xml" => read-xml-report;
+        "json" => read-json-report;
+        otherwise
+          => application-error("can't determine report type; unrecognized filename "
+                                 "extension: %=", extension);
+      end;
   with-open-file (stream = path)
-    // I'm passing path here for convenience of error reporting, but I think we can
-    // remove it and just do the error handling at top level where the path is known.
-    // -cgay 2019
     reader(stream, path, ignored-tests: ignored-tests, ignored-suites: ignored-suites)
   end
 end function;

--- a/reports.dylan
+++ b/reports.dylan
@@ -276,61 +276,6 @@ define method full-report-function
 end method full-report-function;
 
 
-/// Log report
-
-// TODO(cgay): either delete this or replace it with a json report.
-
-define constant $test-log-header = "--------Test Log Report--------";
-define constant $test-log-footer = "--------End Log Report---------";
-
-define method remove-newlines
-    (string :: <string>) => (new-string :: <string>)
-  let string = copy-sequence(string);
-  for (i from 0 below size(string))
-    when (string[i] = '\n')
-      string[i] := ' '
-    end
-  end;
-  string
-end method remove-newlines;
-
-define method log-report-function
-    (result :: <result>, stream :: <stream>) => ()
-  let stream = make(<indenting-stream>, inner-stream: stream);
-  local method generate-report (result :: <result>) => ()
-          let test-type = result-type-name(result);
-          format(stream, "\nObject: %s\n", test-type);
-          format(stream, "Name: %s\n", remove-newlines(result-name(result)));
-          format(stream, "Status: %s\n", status-name(result-status(result)));
-          let status = result.result-status;
-          if (instance?(result, <component-result>))
-            if (result.result-reason)
-              format(stream, "Reason: %s\n", result.result-reason);
-            end;
-            for (subresult in result-subresults(result))
-              with-indentation (stream, 2)
-                generate-report(subresult);
-              end with-indentation;
-            end for;
-          else
-            let reason = result.result-reason;
-            if (reason)
-              format(stream, "Reason: %s\n", remove-newlines(reason));
-            end;
-            if (~reason & instance?(result, <component-result>))
-              format(stream, "Seconds: %s\nAllocation: %d bytes\n",
-                     result-time(result), result-bytes(result) | 0);
-            end if;
-          end;
-          format(stream, "end\n");
-        end method generate-report;
-  format(stream, "\n%s", $test-log-header);
-  generate-report(result);
-  format(stream, "\n%s\n", $test-log-footer);
-  failures-report-function(result, stream)
-end method log-report-function;
-
-
 /// XML report
 
 define constant $xml-version-header


### PR DESCRIPTION
It's currently broken and redundant with the "xml" and "json" formats in any
case.