### PR TITLE
Allow specs to specify expected-to-fail-reason

### DIFF
--- a/documentation/users-guide/source/reference.rst
+++ b/documentation/users-guide/source/reference.rst
@@ -134,7 +134,7 @@ Suites, Tests, and Benchmarks
 
    class specs
 
-     Syntax: *modifiers* class *name* (*superclasses*);
+     Syntax: *modifiers* class *name* (*superclasses*) [, *test-options* ];
 
      *modifiers*
 
@@ -162,9 +162,14 @@ Suites, Tests, and Benchmarks
 
        Comma-separated list of superclass names.
 
+     *test-options*
+
+       Any options valid for :macro:`test-definer`. For example,
+       ``expected-to-fail-reason: "foo"``.
+
    function specs
 
-     Syntax: *modifiers* function *name* (*parameter-types*) => (*value-types*);
+     Syntax: *modifiers* function *name* (*parameter-types*) => (*value-types*) [, *test-options* ];
 
      *modifiers*
 
@@ -196,9 +201,14 @@ Suites, Tests, and Benchmarks
 
        Comma-separated list of return value type names, possibly empty.
 
+     *test-options*
+
+       Any options valid for :macro:`test-definer`. For example,
+       ``expected-to-fail-reason: "foo"``.
+
    variable specs
 
-     Syntax: variable *name* :: *type*;
+     Syntax: variable *name* :: *type* [, *test-options* ];
 
      *name*
 
@@ -208,9 +218,14 @@ Suites, Tests, and Benchmarks
 
        Type of the variable.
 
+     *test-options*
+
+       Any options valid for :macro:`test-definer`. For example,
+       ``expected-to-fail-reason: "foo"``.
+
    constant specs
 
-     Syntax: constant *name* :: *type*;
+     Syntax: constant *name* :: *type* [, *test-options* ];
 
      *name*
 
@@ -219,6 +234,11 @@ Suites, Tests, and Benchmarks
      *type*
 
        Type of the constant.
+
+     *test-options*
+
+       Any options valid for :macro:`test-definer`. For example,
+       ``expected-to-fail-reason: "foo"``.
 
 Assertions
 ----------

--- a/specs.dylan
+++ b/specs.dylan
@@ -88,15 +88,13 @@ define macro binding-spec-suite-definer
   { } => { }
   { ?spec:*; ... } => { ?spec ... }
  spec:
-  { protocol ?protocol-name:name }
-    => { suite ?protocol-name ## "-protocol-test-suite"; }
-  { ?modifiers:* class ?class-name:name (?superclasses:*); }
+  { ?modifiers:* class ?class-name:name (?superclasses:*) ?test-options:* ; }
     => { test "test-" ## ?class-name ## "-specification"; }
-  { ?modifiers:* function ?function-name:name (?parameters:*) => (?results:*); }
+  { ?modifiers:* function ?function-name:name (?parameters:*) => (?results:*) ?test-options:* ; }
     => { test "test-" ## ?function-name ## "-specification"; }
-  { variable ?variable-name:name :: ?type:expression; }
+  { variable ?variable-name:name :: ?type:expression ?test-options:* ; }
     => { test "test-" ## ?variable-name ## "-specification"; }
-  { constant ?constant-name:name :: ?type:expression; }
+  { constant ?constant-name:name :: ?type:expression ?test-options:* ; }
     => { test "test-" ## ?constant-name ## "-specification"; }
 
   // These two allow interface specification suites to be broken up into
@@ -108,11 +106,13 @@ end macro;
 define macro binding-specs-definer
   { define binding-specs ?suite-specification:name (?options:*) end }
     => { }
+
+  // class specs
   { define binding-specs ?suite-specification:name (?options:*)
-      ?modifiers:* class ?class-name:name (?superclasses:*);
+      ?modifiers:* class ?class-name:name (?superclasses:*), #rest ?test-options:* ;
       ?more-specs:*
     end }
-    => { define test "test-" ## ?class-name ## "-specification" ()
+    => { define test "test-" ## ?class-name ## "-specification" (?test-options)
            let class-spec = make(<class-spec>,
                                  name: ?#"class-name",
                                  class: ?class-name,
@@ -124,11 +124,13 @@ define macro binding-specs-definer
          define binding-specs ?suite-specification (?options)
            ?more-specs
          end; }
+
+  // function specs
   { define binding-specs ?suite-specification:name (?options:*)
-      ?modifiers:* function ?function-name:name (?parameters:*) => (?results:*);
+      ?modifiers:* function ?function-name:name (?parameters:*) => (?results:*), #rest ?test-options:* ;
       ?more-specs:*
     end }
-    => { define test "test-" ## ?function-name ## "-specification" ()
+    => { define test "test-" ## ?function-name ## "-specification" (?test-options)
            let function-spec
              = make(<function-spec>,
                     name: ?#"function-name",
@@ -142,11 +144,13 @@ define macro binding-specs-definer
          define binding-specs ?suite-specification (?options)
            ?more-specs
          end; }
+
+  // variable specs
   { define binding-specs ?suite-specification:name (?options:*)
-      variable ?variable-name:name :: ?type:expression;
+      variable ?variable-name:name :: ?type:expression, #rest ?test-options:* ;
       ?more-specs:*
     end }
-    => { define test "test-" ## ?variable-name ## "-specification" ()
+    => { define test "test-" ## ?variable-name ## "-specification" (?test-options)
            let variable-spec
              = make(<variable-spec>,
                     name: ?#"variable-name",
@@ -163,11 +167,13 @@ define macro binding-specs-definer
          define binding-specs ?suite-specification (?options)
            ?more-specs
          end; }
+
+  // constant specs
   { define binding-specs ?suite-specification:name (?options:*)
-      constant ?constant-name:name :: ?type:expression;
+      constant ?constant-name:name :: ?type:expression, #rest ?test-options:* ;
       ?more-specs:*
     end }
-    => { define test "test-" ## ?constant-name ## "-specification" ()
+    => { define test "test-" ## ?constant-name ## "-specification" (?test-options)
            // TODO: Is it possible to generate code for constant specs that
            // tries to set the constant and fails if it works? ...without
            // generating a compiler warning when it's actually constant?
@@ -182,6 +188,7 @@ define macro binding-specs-definer
          define binding-specs ?suite-specification (?options)
            ?more-specs
          end; }
+
   // Drop `test blah;` on the floor; it's handled by `define binding-spec-suite`.
   { define binding-specs ?suite-specification:name (?options:*)
       test ?test-name:name;
@@ -190,6 +197,7 @@ define macro binding-specs-definer
     => { define binding-specs ?suite-specification (?options)
            ?more-specs
          end; }
+
   // Drop `suite blah;` on the floor; it's handled by `define binding-spec-suite`.
   { define binding-specs ?suite-specification:name (?options:*)
       suite ?suite-name:name;

--- a/tests/specification.dylan
+++ b/tests/specification.dylan
@@ -1,6 +1,6 @@
 Module: testworks-test-suite
 
-define interface-specification-suite testworks-interface-specification-test-suite ()
+define interface-specification-suite testworks-interface-specification-suite ()
   function run-test-application (#"rest") => (false-or(<result>));
   function test-output (<string>, #"rest") => ();
   function test-temp-directory () => (false-or(<directory-locator>));
@@ -17,8 +17,25 @@ define interface-specification-suite testworks-interface-specification-test-suit
   open instantiable class <test-runner> (<object>);
 end;
 
+define class <expected-to-fail-class> (<object>) end;
+define variable *expected-to-fail-variable* = #t;
+define constant $expected-to-fail-constant = #"etfc";
+define function expected-to-fail-function () end;
+
+define interface-specification-suite testworks-expected-to-fail-specification-suite ()
+  variable *expected-to-fail-variable* :: <integer>,
+    expected-to-fail-reason: "should be boolean";
+  constant $expected-to-fail-constant :: <string>,
+    expected-to-fail-reason: "should be symbol";
+  instantiable class <expected-to-fail-class> (<integer>),
+    expected-to-fail-reason: "should be object";
+  function expected-to-fail-function (<object>) => (#"rest"),
+    expected-to-fail-reason: "has no args";
+end;
+
 define suite testworks-test-suite ()
-  suite testworks-interface-specification-test-suite;
+  suite testworks-interface-specification-suite;
+  suite testworks-expected-to-fail-specification-suite;
   suite testworks-assertion-macros-suite;
   suite testworks-results-suite;
   suite command-line-test-suite;


### PR DESCRIPTION
Fixes #127 