### PR TITLE
test-temp-directory: Replace / and \ with _

### DIFF
--- a/documentation/source/reference.rst
+++ b/documentation/source/reference.rst
@@ -678,5 +678,8 @@ Test Execution
    and is rooted at ``$DYLAN``, if defined, or in the current directory
    otherwise.
 
+   .. note:: In the ``<test-name>`` component of the directory both slash
+             (``/``) and backslash (``\``) are replaced by underscore (``_``).
+
 
 .. TODO(cgay): document the remaining exported names.

--- a/run.dylan
+++ b/run.dylan
@@ -13,7 +13,7 @@ define thread variable *component* :: false-or(<component>) = #f;
 // Return a temporary directory unique to the current test or benchmark. The
 // directory is created the first time this is called for a given test.
 // The directory is _test/<user>-<yyyymmdd-hhmmss>/<full-test-name>/, relative
-// to ${DYLAN}/, if defined, or fs/working-directory() otherwise.
+// to ${DYLAN}/, if defined, or relative to fs/working-directory() otherwise.
 define function test-temp-directory () => (d :: false-or(<directory-locator>))
   if (instance?(*component*, <runnable>))
     let dylan = os/environment-variable("DYLAN");
@@ -25,8 +25,12 @@ define function test-temp-directory () => (d :: false-or(<directory-locator>))
     let uniquifier
       = format-to-string("%s-%s", os/login-name() | "unknown",
                          date/format("%Y%m%d-%H%M%S", date/now()));
+    let safe-name = map(method (c)
+                          if (c == '\\' | c == '/') '_' else c end
+                        end,
+                        full-component-name(*component*));
     let test-directory
-      = subdirectory-locator(base, "_test", uniquifier, full-component-name(*component*));
+      = subdirectory-locator(base, "_test", uniquifier, safe-name);
     fs/ensure-directories-exist(test-directory);
     test-directory
   end

--- a/tests/testworks-test-suite-library.dylan
+++ b/tests/testworks-test-suite-library.dylan
@@ -28,7 +28,7 @@ define module testworks-test-suite
     prefix: "fs/";
   use format;
   use locators,
-    import: { <directory-locator> };
+    import: { <directory-locator>, locator-name };
   use streams,
     import: { with-output-to-string };
   use strings;

--- a/tests/testworks-test-suite.dylan
+++ b/tests/testworks-test-suite.dylan
@@ -552,6 +552,12 @@ define test test-test-temp-directory () // yes that's a lot of "test"
   assert-true(fs/file-exists?(dir));
 end;
 
+define test test-test-temp-directory/slash-replaced? ()
+  let dir = test-temp-directory();
+  assert-equal("test-test-temp-directory_slash-replaced?",
+               locator-name(dir));
+end;
+
 define test test-register-component--duplicate-test-name-causes-error ()
   let n = size($components);
   let test = make(<test>, name: "t", function: method() end);


### PR DESCRIPTION
I sometimes name tests "test-foo/subtest1", "test-foo/subtest2", and since the test temp directory is named after the test this causes an error.