### PR TITLE
Add workflow to build documentation

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -20,14 +20,17 @@ jobs:
         os: [ ubuntu-latest, macos-latest ]
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           submodules: recursive
 
-      - uses: dylan-lang/install-opendylan@v2
+      - uses: dylan-lang/install-opendylan@v3
+        with:
+          version: 2023.1
+          tag: v2023.1.0
 
       - name: Build testworks-test-suite-app
-        run: ./dylan-compiler -build -jobs 3 testworks-test-suite-app
+        run: dylan-compiler -build -jobs 3 testworks-test-suite-app
 
       - name: Run testworks-test-suite-app
         run: _build/bin/testworks-test-suite-app

--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -1,0 +1,43 @@
+name: Build testworks documentation
+
+on:
+  push:
+    # all branches
+    paths:
+      - 'documentation/**'
+  pull_request:
+    # all branches
+    paths:
+      - 'documentation/**'
+      
+  # This enables the Run Workflow button on the Actions tab.
+  workflow_dispatch:
+
+jobs:
+
+  build-and-deploy:
+    runs-on: ubuntu-latest
+    steps:
+
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Install dylan tool
+        uses: dylan-lang/install-dylan-tool@v2
+
+      - name: Install sphinx-extensions dependencies
+        run: |
+          dylan install -v 0.2.0 sphinx-extensions
+          cp -r /home/runner/dylan/pkg/sphinx-extensions/0.2.0/src/ /home/runner/work/testworks/testworks/sphinx-extensions
+     
+      - name: Build docs
+        uses: ammaraskar/sphinx-action@master
+        with:
+          pre-build-command: "echo furo >> documentation/requirements.txt"
+          docs-folder: "documentation/"
+
+
+      - name: Deploy documents to GH pages
+        uses: JamesIves/github-pages-deploy-action@v4
+        with:
+          folder: documentation/build/html


### PR DESCRIPTION
Build documentation and upload it to Github Pages.

Some updates has been needed:

- Update to actions/checkout@v3 since node v12 is deprecated.  (see https://github.blog/changelog/2023-06-13-github-actions-all-actions-will-run-on-node16-instead-of-node12-by-default/)

- Update action install-opendylan@v3 with compiler version 2023.1 to build in macos

- Update path of dylan-compiler