### PR TITLE
Build tests using 'dylan-tool'

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -21,16 +21,17 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
-        with:
-          submodules: recursive
 
       - uses: dylan-lang/install-opendylan@v3
         with:
           version: 2023.1
           tag: v2023.1.0
 
+      - name: Install dependencies
+        run: dylan update
+
       - name: Build testworks-test-suite-app
-        run: dylan-compiler -build -jobs 3 testworks-test-suite-app
+        run: dylan build testworks-test-suite-app
 
       - name: Run testworks-test-suite-app
         run: _build/bin/testworks-test-suite-app


### PR DESCRIPTION
- Use dylan-tool to build the tests.

- Removing checkout recursive since there are no submodules.