### PR TITLE
Improve --progress and --report output

### DIFF
--- a/assertions.dylan
+++ b/assertions.dylan
@@ -87,14 +87,15 @@ define function do-check-equal
     else
       phase := format-to-string("getting %s failure detail", caller);
       let detail = check-equal-failure-detail(want, got);
+      let detail = if (detail)
+                     format-to-string("\n%s%sdetail: %s",
+                                      *indent*, $indent-step, detail)
+                   else
+                     ""
+                   end;
       record-check(description, $failed,
-                   format-to-string("\n      want: %=\n      got:  %=%s",
-                                    want, got,
-                                    if (detail)
-                                      format-to-string("\n      detail: %s", detail)
-                                    else
-                                      ""
-                                    end));
+                   format-to-string("want: %=\n%s%sgot:  %=%s",
+                                    want, *indent*, $indent-step, got, detail));
       terminate? & signal(make(<assertion-failure>));
     end;
   exception (err :: <serious-condition>, test: method (cond) ~debug?() end)

--- a/assertions.dylan
+++ b/assertions.dylan
@@ -43,80 +43,58 @@ define macro check
 end macro check;
 
 define macro check-equal
-  { check-equal (?name:expression, ?expr1:expression, ?expr2:expression)
+  { check-equal (?name:expression, ?want:expression, ?got:expression)
   } => {
     do-check-equal(method () ?name end,
                    method ()
-                     values(?expr1, ?expr2, ?"expr1", ?"expr2")
+                     values(?want, ?got, ?"want", ?"got")
                    end,
-                   negate?: #f,
+                   "check-equal",
                    terminate?: #f)
   }
 end macro check-equal;
 
 define macro assert-equal
-  { assert-equal (?expr1:expression, ?expr2:expression)
+  { assert-equal (?want:expression, ?got:expression)
   } => {
-    assert-equal(?expr1, ?expr2, ?"expr1" " = " ?"expr2")
+    assert-equal(?want, ?got, ?"want" " = " ?"got")
   }
-  { assert-equal (?expr1:expression, ?expr2:expression, ?description:*)
+  { assert-equal (?want:expression, ?got:expression, ?description:*)
   } => {
     do-check-equal(method () values(?description) end,
                    method ()
-                     values(?expr1, ?expr2, ?"expr1", ?"expr2")
+                     values(?want, ?got, ?"want", ?"got")
                    end,
-                   negate?: #f,
+                   "assert-equal",
                    terminate?: #t)
   }
 end macro assert-equal;
 
-define macro assert-not-equal
-  { assert-not-equal (?expr1:expression, ?expr2:expression)
-  } => {
-    assert-not-equal(?expr1, ?expr2, ?"expr1" " ~= " ?"expr2")
-  }
-  { assert-not-equal (?expr1:expression, ?expr2:expression, ?description:*)
-  } => {
-    do-check-equal(method () values(?description) end,
-                   method ()
-                     values(?expr1, ?expr2, ?"expr1", ?"expr2")
-                   end,
-                   negate?: #t,
-                   terminate?: #t)
-  }
-end macro assert-not-equal;
-
 define function do-check-equal
-    (description-thunk :: <function>, get-arguments :: <function>,
-     #key negate? :: <boolean>,
-          terminate? :: <boolean>)
+    (description-thunk :: <function>, arguments-thunk :: <function>,
+     caller :: <string>, #key terminate? :: <boolean>)
  => ()
   let phase = "evaluating assertion description";
   let description :: false-or(<string>) = #f;
   block ()
     description := eval-check-description(description-thunk);
     phase := "evaluating assertion expressions";
-    let (val1, val2, expr1, expr2) = get-arguments();
-    phase := format-to-string("while comparing %s and %s for %sequality",
-                              expr1, expr2,
-                              if (negate?) "in" else "" end);
-    let compare = if (negate?) \~= else \= end;
-    if (compare(val1, val2))
+    let (want, got, want-expr, got-expr) = arguments-thunk();
+    phase := format-to-string("while comparing %s and %s for equality",
+                              want-expr, got-expr);
+    if (want = got)
       record-check(description, $passed, #f);
     else
-      phase := format-to-string("getting assert-%sequal failure detail",
-                                if (negate?) "not-" else "" end);
-      let detail = if (negate?)
-                     ""
-                   else
-                     check-equal-failure-detail(val1, val2)
-                   end;
+      phase := format-to-string("getting %s failure detail", caller);
+      let detail = check-equal-failure-detail(want, got);
       record-check(description, $failed,
-                   format-to-string("%= and %= are %s=.%s%s",
-                                    val1, val2,
-                                    if (negate?) "" else "not " end,
-                                    if (detail) "  " else "" end,
-                                    detail | ""));
+                   format-to-string("\n      want: %=\n      got:  %=%s",
+                                    want, got,
+                                    if (detail)
+                                      format-to-string("\n      detail: %s", detail)
+                                    else
+                                      ""
+                                    end));
       terminate? & signal(make(<assertion-failure>));
     end;
   exception (err :: <serious-condition>, test: method (cond) ~debug?() end)
@@ -125,10 +103,54 @@ define function do-check-equal
                  format-to-string("Error %s: %s", phase, err));
     terminate? & signal(make(<assertion-failure>));
   end block
-end function do-check-equal;
+end function;
+
+define macro assert-not-equal
+  { assert-not-equal (?expr1:expression, ?expr2:expression)
+  } => {
+    assert-not-equal(?expr1, ?expr2, ?"expr1" " ~= " ?"expr2")
+  }
+  { assert-not-equal (?expr1:expression, ?expr2:expression, ?description:*)
+  } => {
+    do-check-not-equal(method () values(?description) end,
+                       method ()
+                         values(?expr1, ?expr2, ?"expr1", ?"expr2")
+                       end,
+                       terminate?: #t)
+  }
+end macro assert-not-equal;
+
+define function do-check-not-equal
+    (description-thunk :: <function>, arguments-thunk :: <function>,
+     #key terminate? :: <boolean>)
+ => ()
+  let phase = "evaluating assertion description";
+  let description :: false-or(<string>) = #f;
+  block ()
+    description := eval-check-description(description-thunk);
+    phase := "evaluating assertion expressions";
+    let (val1, val2, expr1, expr2) = arguments-thunk();
+    phase := format-to-string("while comparing %s and %s for inequality",
+                              expr1, expr2);
+    if (val1 ~= val2)
+      record-check(description, $passed, #f);
+    else
+      phase := "getting assert-not-equal failure detail";
+      record-check(description, $failed,
+                   format-to-string("%= and %= are =.", val1, val2));
+      terminate? & signal(make(<assertion-failure>));
+    end;
+  exception (err :: <serious-condition>, test: method (cond) ~debug?() end)
+    record-check(description | $invalid-description,
+                 $crashed,
+                 format-to-string("Error %s: %s", phase, err));
+    terminate? & signal(make(<assertion-failure>));
+  end block
+end function;
 
 // Return a string with details about why two objects are not =.
-// Users can override this for their own classes.
+// Users can override this for their own classes. The output should
+// be indented 4 spaces if you want it to display nicely.
 define open generic check-equal-failure-detail
     (val1 :: <object>, val2 :: <object>) => (detail :: false-or(<string>));
 
@@ -142,7 +164,7 @@ define method check-equal-failure-detail
   if (coll1.size ~= coll2.size)
     format-to-string("sizes differ (%d and %d)", coll1.size, coll2.size)
   end
-end method check-equal-failure-detail;
+end method;
 
 define method check-equal-failure-detail
     (seq1 :: <sequence>, seq2 :: <sequence>) => (detail :: false-or(<string>))
@@ -151,14 +173,13 @@ define method check-equal-failure-detail
   for (e1 in seq1, e2 in seq2, i from 0, while: e1 = e2)
   finally
     if (i < seq1.size & i < seq2.size)
-      // TODO(cgay): show the two element values.
-      detail2 := format-to-string("element %d is the first non-matching element", i);
+      detail2 := format-to-string("element %d is the first mismatch", i);
     end;
   end for;
-  join(choose(identity, vector(detail1, detail2)), ", ")
-end method check-equal-failure-detail;
+  join(choose(identity, vector(detail1, detail2)), "; ")
+end method;
 
-// TODO: if key sets are same, compare values. Limit to showing 1 mismatch?
+// TODO: limit the total number of keys/values output
 define method check-equal-failure-detail
     (t1 :: <table>, t2 :: <table>) => (detail :: false-or(<string>))
   let detail1 = next-method();
@@ -174,12 +195,13 @@ define method check-equal-failure-detail
       add!(t2-missing-keys, k);
     end;
   end;
+  let eformat = curry(format-to-string, "%="); // e for escape
   let detail2 = (~empty?(t1-missing-keys)
                    & concatenate("table1 is missing keys ",
-                                 join(sort(t1-missing-keys), ", ")));
+                                 join(t1-missing-keys, ", ", key: eformat)));
   let detail3 = (~empty?(t2-missing-keys)
                    & concatenate("table2 is missing keys ",
-                                 join(sort(t2-missing-keys), ", ")));
+                                 join(t2-missing-keys, ", ", key: eformat)));
   join(choose(identity, vector(detail1, detail2, detail3)), "; ")
 end method;
 

--- a/benchmark.dylan
+++ b/benchmark.dylan
@@ -33,7 +33,7 @@ end;
 define class <benchmark-result> (<component-result>)
 end;
 
-define class <benchmark-iteration-result> (<unit-result>, <metered-result>)
+define class <benchmark-iteration-result> (<metered-result>)
 end;
 
 define method result-type-name

--- a/coloring.dylan
+++ b/coloring.dylan
@@ -14,7 +14,6 @@ define constant $crashed-text-attributes            = text-attributes(foreground
 define constant $expected-to-fail-text-attributes   = text-attributes(foreground: $color-cyan);
 define constant $unexpected-success-text-attributes = text-attributes(foreground: $color-red);
 define constant $component-name-text-attributes     = text-attributes(intensity: $bright-intensity);
-define constant $total-text-attributes              = text-attributes(intensity: $bright-intensity);
 
 define function result-status-to-text-attributes
     (result :: <result-status>)

--- a/components.dylan
+++ b/components.dylan
@@ -117,9 +117,6 @@ end method;
 define class <test> (<runnable>)
 end;
 
-define class <test-unit> (<test>)
-end;
-
 
 define generic component-type-name
     (component :: <component>) => (type-name :: <string>);
@@ -127,11 +124,6 @@ define generic component-type-name
 define method component-type-name
     (test :: <test>) => (type-name :: <string>)
   "test"
-end;
-
-define method component-type-name
-    (test-unit :: <test-unit>) => (type-name :: <string>)
-  "test unit"
 end;
 
 define method component-type-name
@@ -163,11 +155,6 @@ end;
 define method component-result-type
     (component :: <suite>) => (result-type :: subclass(<result>))
   <suite-result>
-end;
-
-define method component-result-type
-    (component :: <test-unit>) => (result-type :: subclass(<result>))
-  <test-unit-result>
 end;
 
 // All tests, benchmarks, and suites are added to this when created.
@@ -242,14 +229,6 @@ define macro benchmark-definer
     register-component(?test-name);
   }
 end macro benchmark-definer;
-
-// For backward compatibility.
-define macro with-test-unit
-  { with-test-unit (?name:expression, ?keyword-args:*)
-      ?test-body:body
-    end
-  } => { ?test-body }
-end macro with-test-unit;
 
 // Find a minimal set of components that cover all tests and return
 // them.

--- a/documentation/source/reference.rst
+++ b/documentation/source/reference.rst
@@ -262,13 +262,13 @@ that this be the case:
     assert-not-equal(5, 2 + 2);
     assert-instance?(<integer>, 2 + 2);
 
-All assertion macros accept a description of what is being tested as
-an *optional* final argument.  The description should be stated in the
-positive sense.  For example:
+All assertion macros accept a format string and format arguments at the end to
+use as the description of the assertion.  The description should be stated in
+the positive sense.  For example:
 
 .. code-block:: dylan
 
-    assert-equal(2, 2 + 2, "2 + 2 equals 2")
+    assert-equal(4, 2 + 2, "2 + 2 equals 4")
 
 These are the available assertion macros:
 
@@ -326,15 +326,17 @@ These are the available assertion macros:
 
 .. macro:: assert-equal
 
-   Assert that two values are equal using ``=`` as the comparison
-   function.  Using this macro is preferable to using ``assert-true(a
-   = b)`` because the failure messages are much better when comparing
-   certain types of objects, such as collections.
+   Assert that two values are equal using :drm:`=` as the comparison function.
+   Using this macro is preferable to using ``assert-true(a = b)`` because the
+   failure messages are much better when comparing certain types of objects,
+   such as collections.
 
-   :signature: assert-equal *expression1* *expression2* [ *description* ]
+   The *expected* value should always be the first expression.
 
-   :parameter expression1: any expression
-   :parameter expression2: any expression
+   :signature: assert-equal *want* *got* [ *description* ... ]
+
+   :parameter want: any expression; traditionally the expected result
+   :parameter got: any expression; traditionally the test result
    :parameter description: An optional description of what the assertion tests.
       This may be a single value of any type or a format string and format
       arguments. It should be stated in positive form, such as "two is less
@@ -346,7 +348,7 @@ These are the available assertion macros:
       .. code-block:: dylan
 
          assert-equal(2, my-complicated-method())
-         assert-equal(this, that, "this and that are the same")
+         assert-equal(want, f(), "f() returned %=", want)
 
 .. macro:: assert-not-equal
 
@@ -370,7 +372,7 @@ These are the available assertion macros:
       .. code-block:: dylan
 
          assert-not-equal(2, my-complicated-method())
-         assert-not-equal(this, that, "this does not equal that")
+         assert-not-equal(want, got, "want does not equal got")
 
 .. macro:: assert-signals
 
@@ -565,7 +567,7 @@ These are the available checks:
 
      .. code-block:: dylan
 
-       check-equal("condition-to-string of an error produces correct string",
+       check-equal("condition-to-string of an error produces the correct string",
                    "Hello",
                    condition-to-string(make(<simple-error>, format-string: "Hello")));
 

--- a/documentation/source/usage.rst
+++ b/documentation/source/usage.rst
@@ -140,9 +140,9 @@ arguments. These are all valid:
 
 .. code-block:: dylan
 
-   assert-equal(a, b);     // auto-generated description
-   assert-equal(a, b, a);  // a used as description
-   assert-equal(a, b, "does %= = %=?", a, b);  // formatted description
+   assert-equal(want, got);       // auto-generated description
+   assert-equal(want, got, foo);  // a used as description
+   assert-equal(want, got, "does %= = %=?", a, b);  // formatted description
 
 Tests
 -----

--- a/dylan-package.json
+++ b/dylan-package.json
@@ -1,7 +1,7 @@
 {
     "name": "testworks",
     "description": "Unit testing framework",
-    "version": "2.3.1",
+    "version": "3.0",
     "keywords": [
         "testing"
     ],

--- a/library.dylan
+++ b/library.dylan
@@ -68,8 +68,7 @@ define module testworks
   create
     suite-definer,
     test-definer,
-    benchmark-definer,
-    with-test-unit;
+    benchmark-definer;
 
   // Benchmarks
   create
@@ -147,7 +146,6 @@ define module %testworks
     <runnable>,
     <benchmark>,
     <test>,
-    <test-unit>,
     test-function,
     test-requires-assertions?,
     test-tags;
@@ -181,12 +179,9 @@ define module %testworks
     <benchmark-result>,
     <benchmark-iteration-result>,
     <suite-result>,
-    <unit-result>,
     result-reason,
     do-results,
-
-    <check-result>,
-    <test-unit-result>;
+    <check-result>;
 
   // Report functions
   export

--- a/library.dylan
+++ b/library.dylan
@@ -34,10 +34,11 @@ define module testworks
     run-tests,
     *runner*,
     <test-runner>,
-    debug-runner?,
+    runner-debug,
     runner-options,
     runner-output-stream,
     runner-progress,
+    runner-debug,
     runner-skip,
     runner-tags;
 
@@ -116,7 +117,7 @@ define module %testworks
     import: { random };
   use standard-io;
   use streams;
-  use strings, import: { char-compare-ic, starts-with?, string-equal? };
+  use strings;
   use testworks;
   use threads,
     import: { dynamic-bind };
@@ -124,6 +125,10 @@ define module %testworks
 
   // Debugging options
   export
+    <debug-option>,
+    $debug-none,
+    $debug-crashes,
+    $debug-all,
     debug-failures?,
     debug?;
 
@@ -194,8 +199,11 @@ define module %testworks
 
   // Progress
   export
-    show-progress,
-    $default, $verbose;
+    $progress-none,
+    $progress-minimal,
+    $progress-all,
+    <progress-option>,
+    show-progress;
 
   // Command line handling
   export

--- a/library.dylan
+++ b/library.dylan
@@ -202,8 +202,7 @@ define module %testworks
     $progress-none,
     $progress-minimal,
     $progress-all,
-    <progress-option>,
-    show-progress;
+    <progress-option>;
 
   // Command line handling
   export

--- a/report/readers.dylan
+++ b/report/readers.dylan
@@ -136,10 +136,6 @@ define method convert-xml-node
       #"test"      => make-component-result(<test-result>);
       #"benchmark" => make-component-result(<benchmark-result>);
       #"iteration" => make-component-result(<benchmark-iteration-result>);
-      #"test-unit"
-        => make(<test-unit-result>,
-                name: name, status: status, reason: reason,
-                subresults: get-subresults());
       #"check"
         => make(<check-result>, name: name, status: status, reason: reason);
       otherwise =>

--- a/report/reports.dylan
+++ b/report/reports.dylan
@@ -36,7 +36,7 @@ define method print-result-reason
   format-out("%s  %s %s%s\n",
              indent, name, status-name(result.result-status),
              if (result.result-reason)
-               format-to-string(" [%s]", result.result-reason)
+               format-to-string(" %s", result.result-reason)
              else
                ""
              end);
@@ -259,7 +259,7 @@ define method print-benchmark-result-footer
     format-out("\n    [*] %d benchmark%s crashed.\n", crashes, plural(crashes));
   end if;
 end method;
-                                        
+
 define method print-benchmark-diff-report
     (top-result :: <comparison-result>, #key show-all? :: <boolean>)
  => ()

--- a/report/reports.dylan
+++ b/report/reports.dylan
@@ -111,7 +111,7 @@ define method print-comparison-info
   print-status-line(result, indent: indent, test: test);
   let result1 = result.comparison-result1;
   let result2 = result.comparison-result2;
-  if (instance?(result1 | result2, <unit-result>))
+  if (instance?(result1 | result2, <check-result>))
     print-reason(result, indent: indent, test: test);
   end;
   let subindent = concatenate-as(<byte-string>, indent, "  ");

--- a/reports.dylan
+++ b/reports.dylan
@@ -153,7 +153,7 @@ end method print-result-info;
 
 // This 'after' method prints the reason for the result's failure
 define method print-result-info
-    (result :: <unit-result>, stream :: <stream>, #key indent = "", test) => ()
+    (result :: <check-result>, stream :: <stream>, #key indent = "", test) => ()
   ignore(indent);
   next-method();
   let show-result? = if (test) test(result) else #t end;
@@ -424,11 +424,7 @@ define function emit-surefire-test
     $not-implemented =>
       format(stream, "\n      <failure message=\"Not implemented\" />\n");
     otherwise =>
-      // If this test failed then we know at least one of the checks
-      // failed.  Note that (due to testworks-specs) a <test-result>
-      // may contain <test-unit-result>s and we flatten those into
-      // this result because they don't (apparently?) match Surefire's
-      // format.
+      // If this test failed then we know at least one of the checks failed.
       format(stream, "\n      <failure>\n");
       do-results(rcurry(emit-surefire-check, stream), test,
                  test: rcurry(instance?, <check-result>));

--- a/reports.dylan
+++ b/reports.dylan
@@ -143,7 +143,7 @@ define method print-result-info
   let show-result? = if (test) test(result) else #t end;
   let reason = result.result-reason;
   if (show-result? & reason)
-    format(stream, " [%s]", reason);
+    format(stream, "%s", reason);
   end;
   let subindent = concatenate(indent, "  ");
   for (subresult in result-subresults(result))
@@ -159,7 +159,7 @@ define method print-result-info
   let show-result? = if (test) test(result) else #t end;
   let reason = result.result-reason;
   if (show-result? & reason)
-    format(stream, " [%s]", reason);
+    format(stream, "%s", reason);
   end;
 end method print-result-info;
 

--- a/reports.dylan
+++ b/reports.dylan
@@ -258,11 +258,13 @@ end method;
 define method print-failures-report
     (result :: <result>, stream :: <stream>) => ()
   if (result.result-status ~= $passed)
-    print-result-info (result, stream,
-                       test: method (result)
-                               let status = result.result-status;
-                               status ~== $passed & status ~== $skipped
-                             end);
+    print-result-info(result, stream,
+                      test: method (result)
+                              select (result.result-status)
+                                $passed, $skipped, $expected-failure => #f;
+                                otherwise => #t;
+                              end
+                            end);
     format(stream, "\n");
   end;
   print-summary-report(result, stream);

--- a/results.dylan
+++ b/results.dylan
@@ -43,13 +43,14 @@ end method status-name;
 define generic result-name   (result :: <result>) => (name :: <string>);
 define generic result-status (result :: <result>) => (status :: <result-status>);
 define generic result-reason (result :: <result>) => (reason :: false-or(<string>));
+define generic result-passing? (result :: <result>) => (passing? :: <boolean>);
 
 define class <result> (<object>)
   constant slot result-name :: <string>,
     required-init-keyword: name:;
   constant slot result-status :: <result-status>,
     required-init-keyword: status:;
-  // This is #f if the test passed; otherwise a string.
+  // This is #f if the test passed.
   constant slot result-reason :: false-or(<string>) = #f,
     required-init-keyword: reason:;
 end class <result>;
@@ -63,7 +64,6 @@ define class <metered-result> (<result>)
     required-init-keyword: seconds:;
   constant slot result-microseconds :: false-or(<integer>),
     required-init-keyword: microseconds:;
-  // Hopefully nothing will allocate more than 536MB haha...
   constant slot result-bytes :: false-or(<integer>),
     required-init-keyword: bytes:;
 end class <metered-result>;
@@ -84,7 +84,6 @@ end;
 define class <check-result> (<result>)
 end;
 
-
 // I believe this is for testworks-report.  --cgay
 define method \=
     (result1 :: <result>, result2 :: <result>)
@@ -94,6 +93,11 @@ define method \=
      | result1.result-reason = result2.result-reason)
 end;
 
+
+define method result-passing?
+    (result :: <result>) => (passing? :: <boolean>)
+  member?(result.result-status, $passing-statuses)
+end method;
 
 define open generic result-type-name
     (result :: <result>) => (name :: <string>);

--- a/results.dylan
+++ b/results.dylan
@@ -81,13 +81,7 @@ end;
 define class <suite-result> (<component-result>)
 end;
 
-define class <unit-result> (<result>)
-end;
-
-define class <check-result> (<unit-result>)
-end;
-
-define class <test-unit-result> (<test-result>, <unit-result>)
+define class <check-result> (<result>)
 end;
 
 
@@ -117,11 +111,6 @@ end;
 define method result-type-name
     (result :: <check-result>) => (name :: <string>)
   "check"
-end;
-
-define method result-type-name
-    (result :: <test-unit-result>) => (name :: <string>)
-  "test-unit"
 end;
 
 

--- a/run.dylan
+++ b/run.dylan
@@ -325,7 +325,7 @@ define function decide-status
          end;
     empty?(subresults) & ~benchmark?
       => $not-implemented;
-    every?(method (result :: <unit-result>) => (passed? :: <boolean>)
+    every?(method (result :: <result>) => (passed? :: <boolean>)
              result.result-status == $passed
            end,
            subresults)

--- a/run.dylan
+++ b/run.dylan
@@ -369,9 +369,7 @@ define method list-component
   end if;
   sublist
 end method list-component;
-    
 
-// TODO(cgay): Use indentation to show suite nesting.
 
 // Show some output during the test run.  For each component this is
 // called both before and after it has been run.  If before, result
@@ -455,9 +453,9 @@ define method show-progress
                 status.status-name.as-uppercase,
                 $reset-text-attributes,
                 result.result-name,
-                reason & concatenate(" [", reason, "]") | "");
+                reason & concatenate(" ", reason) | "");
   elseif (reason)
-    test-output("\n  %s: [%s]\n  ", result.result-name, reason);
+    test-output("\n  %s: %s", result.result-name, reason);
   end;
 end method show-progress;
 

--- a/tests/specification.dylan
+++ b/tests/specification.dylan
@@ -7,10 +7,10 @@ define interface-specification-suite testworks-interface-specification-suite ()
   open generic function check-equal-failure-detail (<object>, <object>) => (false-or(<string>));
 
   // For extending the runner capabilities.
-  function debug-runner? (<test-runner>) => (<object>);
+  function runner-debug (<test-runner>) => (<debug-option>);
   function run-tests (<test-runner>, <component>) => (<component-result>);
   function runner-output-stream (<test-runner>) => (<stream>);
-  function runner-progress (<test-runner>) => (one-of(#f, $default, $verbose));
+  function runner-progress (<test-runner>) => (<progress-option>);
   function runner-skip (<test-runner>) => (<sequence>);
   function runner-tags (<test-runner>) => (<sequence>);
   function test-option (<string>, #"key", #"default") => (<string>);

--- a/tests/specification.dylan
+++ b/tests/specification.dylan
@@ -53,5 +53,4 @@ define suite testworks-test-suite ()
   test test-test-temp-directory;
   test test-that-not-implemented-is-not-a-failure;
   test test-that-not-implemented-plus-passed-is-passed;
-  test test-with-test-unit;
 end suite;

--- a/tests/test-command-line.dylan
+++ b/tests/test-command-line.dylan
@@ -5,10 +5,10 @@ Synopsis: Tests for command-line.dylan
 define constant $dummy-suite = make(<suite>, name: "Dummy", components: #());
 
 define test command-line-options-test ()
-  let args = list(list("--debug=no", debug-runner?, #f, #f),
-                  list("--debug=crashes", debug-runner?, #"crashes", #f),
-                  list("--debug=failures", debug-runner?, #t, #f),
-                  list("--debug=foo", debug-runner?, #f, #t),
+  let args = list(list("--debug=none", runner-debug, $debug-none, #f),
+                  list("--debug=crashes", runner-debug, $debug-crashes, #f),
+                  list("--debug=all", runner-debug, $debug-all, #f),
+                  list("--debug=foo", runner-debug, $debug-none, #t),
                   list("--options key1 = val1 --options key2 = val2", runner-options,
                        begin
                          let t = make(<string-table>);

--- a/tests/testworks-test-suite.dylan
+++ b/tests/testworks-test-suite.dylan
@@ -15,7 +15,8 @@ define function do-with-result
   let test = make(<test>,
                   name: "anonymous",
                   function: thunk);
-  let result = run-tests(make(<test-runner>, progress: #f), test);
+  let result = run-tests(make(<test-runner>, progress: $progress-none),
+                         test);
   let subresults = result.result-subresults;
   assert-equal(1, subresults.size,
                "assertion-status thunk had exactly one assertion?");
@@ -346,7 +347,7 @@ end;
 /// Verify the result objects
 
 define test test-run-tests/test ()
-  let runner = make(<test-runner>, progress: #f);
+  let runner = make(<test-runner>, progress: $progress-none);
   let test-results = run-tests(runner, testworks-check-test);
   assert-true(instance?(test-results, <test-result>),
               "run-tests returns <test-result> when running a <test>");
@@ -362,7 +363,7 @@ end test test-run-tests/test;
 
 define test test-run-tests/suite ()
   let suite-to-check = testworks-assertion-macros-suite;
-  let runner = make(<test-runner>, progress: #f);
+  let runner = make(<test-runner>, progress: $progress-none);
   let suite-results = run-tests(runner, suite-to-check);
   assert-true(instance?(suite-results, <suite-result>),
               "run-tests returns <suite-result> when running a <suite>");
@@ -418,7 +419,7 @@ define constant unexpected-success-suite
          components: vector(test-unexpected-success));
 
 define test test-run-tests-expect-failure/suite ()
-  let runner = make(<test-runner>, progress: #f);
+  let runner = make(<test-runner>, progress: $progress-none);
 
   let suite-results = run-tests(runner, expected-to-fail-suite);
   assert-equal($passed, suite-results.result-status,
@@ -432,7 +433,7 @@ define test test-run-tests-expect-failure/suite ()
 end test;
 
 define test test-run-tests-expect-failure/test ()
-  let runner = make(<test-runner>, progress: #f);
+  let runner = make(<test-runner>, progress: $progress-none);
 
   let test-results = run-tests(runner, test-expected-to-fail-always);
   assert-equal($expected-failure, test-results.result-status);
@@ -578,7 +579,7 @@ define test test-that-not-implemented-is-not-a-failure ()
   let suite = make(<suite>,
                    name: "not-implemented-suite",
                    components: vector(test));
-  let runner = make(<test-runner>, progress: #f);
+  let runner = make(<test-runner>, progress: $progress-none);
   let result = run-tests(runner, suite);
   assert-equal($not-implemented, result.result-status);
 end;
@@ -593,7 +594,7 @@ define test test-that-not-implemented-plus-passed-is-passed ()
   let suite = make(<suite>,
                    name: "not-implemented-suite",
                    components: vector(test1, test2));
-  let runner = make(<test-runner>, progress: #f);
+  let runner = make(<test-runner>, progress: $progress-none);
   let result = run-tests(runner, suite);
   assert-equal($passed, result.result-status);
 end;
@@ -628,7 +629,8 @@ define function check-description (test-function, want-string)
   let test = make(<test>,
                   name: "no name",
                   function: test-function);
-  let result = run-tests(make(<test-runner>, progress: #f), test);
+  let result = run-tests(make(<test-runner>, progress: $progress-none),
+                         test);
   let report = with-output-to-string (stream)
                  print-full-report(result, stream)
                end;
@@ -746,6 +748,11 @@ end test;
  work to be done in this area so I expect to use these more.
 
 define test test-assert-equal-output ()
+  check-instance?("b", <string>, 1);
+  check-true("d", 3 < 2);
+  check-false("e", 3 == 3);
+  check-condition("f", <error>, "no error");
+  check-no-condition("g", error("foo"));
   check-equal("list, same size, different elements",
               #("a", "b", "c", "d"),
               #("a", "b", "x", "d"));

--- a/tests/testworks-test-suite.dylan
+++ b/tests/testworks-test-suite.dylan
@@ -372,18 +372,6 @@ define test test-run-tests/suite ()
               "run-tests sub-results are in a vector");
 end test test-run-tests/suite;
 
-// This simply exercises the with-test-unit macro.  It'll catch
-// compile time warnings at least, but doesn't actually verify
-// anything else.
-define test test-with-test-unit ()
-  with-test-unit ("foo-unit")
-    assert-equal(2, 2);
-  end;
-  with-test-unit ("bar-unit")
-    assert-equal(3, 3);
-  end;
-end test test-with-test-unit;
-
 // The following tests and suites are defined without using their
 // respective -definer macros so that they don't get registered and
 // then run as normal tests (which would fail).

--- a/utils.dylan
+++ b/utils.dylan
@@ -110,3 +110,18 @@ define function format-bytes
                          end;
   concatenate(integer-to-string(round/(bytes, divisor)), units)
 end function format-bytes;
+
+define function capitalize
+    (string :: <string>) => (_ :: <string>)
+  concatenate(as-uppercase(copy-sequence(string, end: 1)),
+              copy-sequence(string, start: 1))
+end function;
+
+// For --progress and --report=full
+define thread variable *indent* :: <string> = "";
+
+define constant $indent-step :: <string> = "  ";
+
+define function next-indent () => (indent :: <string>)
+  concatenate(*indent*, $indent-step)
+end function;


### PR DESCRIPTION
For example, the failures report now looks like this:
```
$ _build/bin/testworks-test-suite-app --progress none
FAILED: testworks-test-suite-app
  FAILED: test-assert-equal-output
    FAILED: b
      1 (from expression "1") is not an instance of {class <string>}.
    FAILED: f
      no condition signaled
    CRASHED: g
      Error evaluating assertion expression: foo
    FAILED: list, same size, different elements
      want: #("a", "b", "c", "d")
      got:  #("a", "b", "x", "d")
      detail: element 2 is the first mismatch
      ...
Ran 1289 assertions
Ran 54 tests and 2 benchmarks: 1 failed and 4 expected failures
FAILED in 0.312805 seconds
```