### PR TITLE
Add expect-true macro for symmetry with expect-false

### DIFF
--- a/assertions.dylan
+++ b/assertions.dylan
@@ -54,6 +54,19 @@ define macro expect
   }
 end macro;
 
+// This is for symmetry with expect-false. Usually expect is preferred.
+define macro expect-true
+    { expect-true(?expr:expression) }
+ => { expect-true(?expr, ?"expr" " is true") }
+
+    { expect-true(?expr:expression, ?description:*) }
+ => { do-check-true(method () values(?description) end,
+                    method () values(?expr, ?"expr") end,
+                    "expect",
+                    terminate?: #f)
+  }
+end macro;
+
 // Deprecated; use expect-equal.
 define macro check-equal
     { check-equal(?description:expression, ?want:expression, ?got:expression) }

--- a/library.dylan
+++ b/library.dylan
@@ -67,6 +67,7 @@ define module testworks
     expect,
     expect-equal,
     expect-not-equal,
+    expect-true,
     expect-false,
     expect-instance?,
     expect-not-instance?,

--- a/tests/testworks-test-suite.dylan
+++ b/tests/testworks-test-suite.dylan
@@ -109,6 +109,21 @@ define test test-expect ()
                "expect of error crashes");
 end test;
 
+define test test-expect-true ()
+  expect-true(always(#t));
+  expect-true(identity(#t));
+  expect-true(3 = 3);
+  assert-equal($passed,
+               with-result-status () expect-true(#t) end,
+               "expect(#t) passes");
+  assert-equal($failed,
+               with-result-status () expect-true(#f) end,
+               "expect(#f) fails");
+  assert-equal($crashed,
+               with-result-status () expect-true(test-error()) end,
+               "expect of error crashes");
+end test;
+
 define test testworks-assert-true-test ()
   assert-true(#t);
   assert-true(#t, "#t is true with description");


### PR DESCRIPTION
And for symmetry with assert-true/false. 

Editorializing a bit, I think we really only need the expect/assert and expect/assert-equal variants, but this is where we're at so I'm not gonna fight it. 