### PR TITLE
Run suite setup/cleanup when --test is used

### DIFF
--- a/library.dylan
+++ b/library.dylan
@@ -7,6 +7,7 @@ License:      See License.txt in this distribution for details.
 Warranty:     Distributed WITHOUT WARRANTY OF ANY KIND
 
 define library testworks
+  use collections;
   use command-line-parser;
   use common-dylan,
     import: { common-dylan, simple-random, threads };
@@ -34,13 +35,11 @@ define module testworks
     run-tests,
     *runner*,
     <test-runner>,
+    runner-components,
     runner-debug,
     runner-options,
     runner-output-stream,
-    runner-progress,
-    runner-debug,
-    runner-skip,
-    runner-tags;
+    runner-progress;
 
   // Checks (deprecated, use assert-* or expect-*)
   create
@@ -126,6 +125,7 @@ define module %testworks
   use operating-system,
     prefix: "os/";
   use print, import: { print-object };
+  use set;
   use simple-random,
     import: { random };
   use standard-io;
@@ -154,6 +154,8 @@ define module %testworks
     <component>,
     $components,
     *component*,
+    compute-components,
+    do-components,
     register-component,
     execute-component?,
     component-name,

--- a/tests/specification.dylan
+++ b/tests/specification.dylan
@@ -7,12 +7,11 @@ define interface-specification-suite testworks-interface-specification-suite ()
   open generic function check-equal-failure-detail (<object>, <object>) => (false-or(<string>));
 
   // For extending the runner capabilities.
-  function runner-debug (<test-runner>) => (<debug-option>);
   function run-tests (<test-runner>, <component>) => (<component-result>);
+  function runner-debug         (<test-runner>) => (<debug-option>);
   function runner-output-stream (<test-runner>) => (<stream>);
-  function runner-progress (<test-runner>) => (<progress-option>);
-  function runner-skip (<test-runner>) => (<sequence>);
-  function runner-tags (<test-runner>) => (<sequence>);
+  function runner-progress      (<test-runner>) => (<progress-option>);
+  function runner-components    (<test-runner>) => (<collection>);
   function test-option (<string>, #"key", #"default") => (<string>);
   open instantiable class <test-runner> (<object>);
 end;

--- a/tests/test-command-line.dylan
+++ b/tests/test-command-line.dylan
@@ -33,7 +33,7 @@ define test command-line-options-test ()
                      options);
     else
       let parser = parse-args(split(options, " "));
-      let (_, runner, _) = make-runner-from-command-line($dummy-suite, parser);
+      let runner = make-runner-from-command-line($dummy-suite, parser);
       let actual = getter(runner);
       assert-equal(actual, expected, options);
     end;


### PR DESCRIPTION
This changes the way the runner works a little bit. Instead of checking tags and looking for suite setup/cleanup during the test run everything is computed in advance and the exact set of components that will be executed based on command-line args is stored in the runner-components slot. If a suite is in that set, then its setup/cleanup need to be run. This also meant that runner-tags and runner-skip were no longer needed.

Fixes #148