### PR TITLE
Remove dependence on "strings" library, use latest sphinx-extensions

### DIFF
--- a/command-line.dylan
+++ b/command-line.dylan
@@ -131,12 +131,12 @@ define function make-runner-from-command-line
                          parse-tags(get-option-value(parser, "tag")),
                          get-option-value(parser, "run"),
                          get-option-value(parser, "skip"));
-  let debug = select (get-option-value(parser, "debug") by string-equal-ic?)
+  let debug = select (as-lowercase(get-option-value(parser, "debug")) by \=)
                 "none"    => $debug-none;
                 "crashes" => $debug-crashes;
                 "all"     => $debug-all;
               end;
-  let progress = select (get-option-value(parser, "progress") by string-equal-ic?)
+  let progress = select (as-lowercase(get-option-value(parser, "progress")) by \=)
                    "none"    => $progress-none;
                    "minimal" => $progress-minimal;
                    "all"     => $progress-all;

--- a/dylan-package.json
+++ b/dylan-package.json
@@ -8,10 +8,9 @@
     "dependencies": [
         "command-line-parser@3.1.1",
         "json@1.0",
-        "strings@1.1"
     ],
     "dev-dependencies": [
-	"sphinx-extensions@0.2.0"
+	"sphinx-extensions"
     ],
     "url": "https://github.com/dylan-lang/testworks"
 }

--- a/library.dylan
+++ b/library.dylan
@@ -15,7 +15,6 @@ define library testworks
   use io,
     import: { format, print, standard-io, streams };
   use coloring-stream;
-  use strings;
   use system,
     import: { date, file-system, locators, operating-system };
   use memory-manager;
@@ -130,7 +129,6 @@ define module %testworks
     import: { random };
   use standard-io;
   use streams;
-  use strings;
   use testworks;
   use threads,
     import: { dynamic-bind };

--- a/utils.dylan
+++ b/utils.dylan
@@ -33,7 +33,7 @@ end;
 
 define method make-tag
     (spec :: <string>) => (tag :: <tag>)
-  let negated? = starts-with?(spec, "-");
+  let negated? = (~empty?(spec) & spec[0] == '-');
   let name = copy-sequence(spec, start: negated? & 1 | 0);
   if (empty?(name))
     error("Invalid tag: %=", spec);


### PR DESCRIPTION
There are trivial workarounds for use of the strings library so remove the dependency to avoid potential version conflicts given that almost every other library uses Testworks as a dev dependency.

Also switched the sphinx-extensions dev dependency from a specific version to latest, for the same reason.

Fixes #172
Related to https://github.com/dylan-lang/deft/issues/43