### PR TITLE
Fix build-and-test.yml

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -28,9 +28,6 @@ jobs:
 
       - name: Install Opendylan compiler
         uses: dylan-lang/install-opendylan@v3
-        with:
-          version: 2023.1
-          tag: v2023.1.0
 
       - name: Install dependencies
         run: dylan update

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -37,7 +37,7 @@ jobs:
 
       - name: Run testworks-test-suite-app
         run: |
-          _build/bin/testworks-test-suite-app --progress none --report surefire > _build/TEST-testworks.xml
+          _build/bin/testworks-test-suite-app --report surefire --report-file _build/TEST-testworks.xml
 
       - name: Publish Test Report
         if: success() || failure()

--- a/tests/testworks-test-suite.dylan
+++ b/tests/testworks-test-suite.dylan
@@ -867,7 +867,7 @@ define test test-assertion-description ()
   check-description(method () assert-equal(#t, #t, "%d", 456); end, "456");
 
   // assert-true
-  check-description(method () assert-true(#t);            end, "#t is true");
+  check-description(method () assert-true(#t);            end, "PASSED: #t");
   check-description(method () assert-true(#t, 123);       end, "123");
   check-description(method () assert-true(#t, "abc");     end, "abc");
   check-description(method () assert-true(#t, "%d", 456); end, "456");


### PR DESCRIPTION
See the red rectangle.

<img width="1056" alt="Screenshot 2025-05-03 at 9 02 19 PM" src="https://github.com/user-attachments/assets/195397a1-df75-449f-b140-f12ec8e465d5" />

Also use `--report-file`, which is better because it allows default progress output to be written to the workflow logs.